### PR TITLE
1.0.3: Added "Generated" marker to types and fixed a bug.

### DIFF
--- a/DomainModeling.Generator/DummyBuilderGenerator.cs
+++ b/DomainModeling.Generator/DummyBuilderGenerator.cs
@@ -271,7 +271,7 @@ namespace {containingNamespace}
 	/// That way, if the constructor changes, only the builder needs to be adjusted, rather than lots of test methods.
 	/// </para>
 	/// </summary>
-	public partial class {typeName}
+	/* Generated */ public partial class {typeName}
 	{{
 #nullable disable
 

--- a/DomainModeling.Generator/IdentityGenerator.cs
+++ b/DomainModeling.Generator/IdentityGenerator.cs
@@ -309,7 +309,7 @@ namespace {containingNamespace}
 	{(existingComponents.HasFlags(IdTypeComponents.NewtonsoftJsonConverter) ? "*/" : "")}
 
 	{(hasSourceGeneratedAttribute ? "" : "[SourceGenerated]")}
-	{accessibility.ToCodeString()} readonly{(entityTypeName is null ? " partial" : "")} struct {idTypeName} : {Constants.IdentityInterfaceTypeName}<{underlyingTypeFullyQualifiedName}>, IEquatable<{idTypeName}>, IComparable<{idTypeName}>
+	{(entityTypeName is null ? "/* Generated */ " : "")}{accessibility.ToCodeString()} readonly{(entityTypeName is null ? " partial" : "")} struct {idTypeName} : {Constants.IdentityInterfaceTypeName}<{underlyingTypeFullyQualifiedName}>, IEquatable<{idTypeName}>, IComparable<{idTypeName}>
 	{{
 		{(existingComponents.HasFlags(IdTypeComponents.Value) ? "/*" : "")}
 		{nonNullStringSummary}

--- a/DomainModeling.Generator/SourceGeneratedAttributeAnalyzer.cs
+++ b/DomainModeling.Generator/SourceGeneratedAttributeAnalyzer.cs
@@ -48,14 +48,14 @@ public class SourceGeneratedAttributeAnalyzer : SourceGenerator
 		var hasMissingPartialKeyword = !tds.Modifiers.Any(SyntaxKind.PartialKeyword);
 
 		string? expectedTypeName = null;
-		if (type.IsOrImplementsInterface(type => type.Arity == 1 && type.IsType(Constants.IdentityInterfaceTypeName, Constants.DomainModelingNamespace), out _))
-			expectedTypeName = tds is StructDeclarationSyntax ? null : "struct"; // Expect a struct
-		else if (type.IsOrInheritsClass(type => type.Arity == 1 && type.IsType(Constants.WrapperValueObjectTypeName, Constants.DomainModelingNamespace), out _))
+		if (type.IsOrInheritsClass(type => type.Arity == 1 && type.IsType(Constants.WrapperValueObjectTypeName, Constants.DomainModelingNamespace), out _))
 			expectedTypeName = tds is ClassDeclarationSyntax ? null : "class"; // Expect a class
 		else if (type.IsOrInheritsClass(type => type.Arity == 0 && type.IsType(Constants.ValueObjectTypeName, Constants.DomainModelingNamespace), out _))
 			expectedTypeName = tds is ClassDeclarationSyntax ? null : "class"; // Expect a class
 		else if (type.IsOrInheritsClass(type => type.Arity == 2 && type.IsType(Constants.DummyBuilderTypeName, Constants.DomainModelingNamespace), out _))
 			expectedTypeName = tds is ClassDeclarationSyntax ? null : "class"; // Expect a class
+		else if (type.IsOrImplementsInterface(type => type.Arity == 1 && type.IsType(Constants.IdentityInterfaceTypeName, Constants.DomainModelingNamespace), out _))
+			expectedTypeName = tds is StructDeclarationSyntax ? null : "struct"; // Expect a struct
 		else
 			expectedTypeName = "*"; // No suitable inheritance found for source generation
 

--- a/DomainModeling.Generator/ValueObjectGenerator.cs
+++ b/DomainModeling.Generator/ValueObjectGenerator.cs
@@ -252,7 +252,7 @@ namespace {containingNamespace}
 	[Serializable]
 	{(existingComponents.HasFlags(ValueObjectTypeComponents.SerializableAttribute) ? "*/" : "")}
 
-	{type.DeclaredAccessibility.ToCodeString()} sealed partial {(isRecord ? "record" : "class")} {typeName} : IEquatable<{typeName}>{(isComparable ? "" : "/*")}, IComparable<{typeName}>{(isComparable ? "" : "*/")}
+	/* Generated */ {type.DeclaredAccessibility.ToCodeString()} sealed partial {(isRecord ? "record" : "class")} {typeName} : IEquatable<{typeName}>{(isComparable ? "" : "/*")}, IComparable<{typeName}>{(isComparable ? "" : "*/")}
 	{{
 		{(isRecord || existingComponents.HasFlags(ValueObjectTypeComponents.StringComparison) ? "/*" : "")}
 		{(dataMembers.Any(member => member.Type.IsType<string>())

--- a/DomainModeling.Generator/WrapperValueObjectGenerator.cs
+++ b/DomainModeling.Generator/WrapperValueObjectGenerator.cs
@@ -222,7 +222,7 @@ namespace {containingNamespace}
 	[Newtonsoft.Json.JsonConverter(typeof({typeName}.NewtonsoftJsonConverter))]
 	{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.NewtonsoftJsonConverter) ? "*/" : "")}
 
-	{type.DeclaredAccessibility.ToCodeString()} sealed partial class {typeName} : IEquatable<{typeName}>{(isComparable ? "" : "/*")}, IComparable<{typeName}>{(isComparable ? "" : "*/")}
+	/* Generated */ {type.DeclaredAccessibility.ToCodeString()} sealed partial class {typeName} : IEquatable<{typeName}>{(isComparable ? "" : "/*")}, IComparable<{typeName}>{(isComparable ? "" : "*/")}
 	{{
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.StringComparison) ? "/*" : "")}
 		{(underlyingType.IsType<string>() ? "" : @"protected sealed override StringComparison StringComparison => throw new NotSupportedException(""This operation applies to string-based value objects only."");")}

--- a/DomainModeling.Tests/Comparisons/DictionaryComparerTests.cs
+++ b/DomainModeling.Tests/Comparisons/DictionaryComparerTests.cs
@@ -133,7 +133,7 @@ public class DictionaryComparerTests
 	{
 		var left = new Dictionary<int, string>() { [1] = leftValue };
 		var right = new Dictionary<int, string>() { [1] = rightValue };
-		
+
 		var result = DictionaryComparer.DictionaryEquals(left, right);
 
 		Assert.Equal(expectedResult, result);

--- a/DomainModeling.Tests/DummyBuilderTests.cs
+++ b/DomainModeling.Tests/DummyBuilderTests.cs
@@ -62,7 +62,7 @@ namespace Architect.DomainModeling.Tests
 			public DateTimeOffset ModificationDateTime { get; }
 			public ushort Count { get; }
 			public Money Amount { get; }
-			
+
 			/// <summary>
 			/// The type's simplest non-default constructor should be used by the builder.
 			/// </summary>

--- a/DomainModeling.Tests/Entities/EntityTests.cs
+++ b/DomainModeling.Tests/Entities/EntityTests.cs
@@ -12,7 +12,7 @@ public class EntityTests
 	public void DefaultId_WithClassId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
 		var instance = new ClassIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		
+
 		Assert.Equal(expectedResult, instance.HasDefaultId());
 	}
 
@@ -176,7 +176,7 @@ public class EntityTests
 	{
 		var one = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
 		var two = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		
+
 		Assert.Equal(expectedResult, one.GetHashCode().Equals(two.GetHashCode()));
 	}
 

--- a/DomainModeling.Tests/IdentityTests.cs
+++ b/DomainModeling.Tests/IdentityTests.cs
@@ -451,7 +451,7 @@ namespace Architect.DomainModeling.Tests
 			CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
 
 			Assert.Equal(value, Newtonsoft.Json.JsonConvert.DeserializeObject<DecimalId?>(json)?.Value);
-			
+
 			if (json != "null")
 				Assert.Equal((decimal)value, System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json).Value);
 		}

--- a/DomainModeling.Tests/ValueObjectTests.cs
+++ b/DomainModeling.Tests/ValueObjectTests.cs
@@ -1107,12 +1107,12 @@ namespace Architect.DomainModeling.Tests
 			{
 				return typeof(FullySelfImplementedValueObject).GetHashCode();
 			}
-			
+
 			public sealed override bool Equals([AllowNull] object other)
 			{
 				return other is FullySelfImplementedValueObject otherValue && this.Equals(otherValue);
 			}
-			
+
 			public bool Equals([AllowNull] FullySelfImplementedValueObject other)
 			{
 				if (other is null) return false;

--- a/DomainModeling.Tests/ValueObjectTests.cs
+++ b/DomainModeling.Tests/ValueObjectTests.cs
@@ -969,6 +969,11 @@ namespace Architect.DomainModeling.Tests
 	namespace ValueObjectTestTypes
 	{
 		[SourceGenerated]
+		public sealed partial class ValueObjectWithIIdentity : ValueObject, IIdentity<int>
+		{
+		}
+
+		[SourceGenerated]
 		public sealed partial class IntValue : ValueObject
 		{
 			public int One { get; }

--- a/DomainModeling.Tests/WrapperValueObjectTests.cs
+++ b/DomainModeling.Tests/WrapperValueObjectTests.cs
@@ -436,6 +436,11 @@ namespace Architect.DomainModeling.Tests
 		}
 
 		[SourceGenerated]
+		public sealed partial class WrapperValueObjectWithIIdentity : WrapperValueObject<int>, IIdentity<int>
+		{
+		}
+
+		[SourceGenerated]
 		public sealed partial class IntValue : WrapperValueObject<int>
 		{
 			public StringComparison GetStringComparison() => this.StringComparison;

--- a/DomainModeling/DomainModeling.csproj
+++ b/DomainModeling/DomainModeling.csproj
@@ -28,7 +28,9 @@ Release notes:
 
 1.0.3:
 - Improved performance by using incremental generators.
+- Made it easier to navigate into the right file, thanks to a comment just before the generated type definition.
 - Generated source now uses the common .g.cs suffix.
+- Fixed a compile-time bug where [Wrapper]ValueObject inheritance combined with the IIdentity interface would cause an unwarranted warning.
 - Fixed a compile-time bug where the source generator would fail to acknowledge a type with the SourceGeneratedAttribute on one partial and the required base type on another.
 - Fixed a compile-time bug where the source generator would crash if the partial to be extended already consisted of multiple partials.
 - Fixed a compile-time bug where the DummyBuilder source generator would crash if it encountered a constructor taking a parameter that is a source-generated IIdentity.

--- a/DomainModeling/IIdentity.cs
+++ b/DomainModeling/IIdentity.cs
@@ -1,4 +1,4 @@
-﻿namespace Architect.DomainModeling;
+namespace Architect.DomainModeling;
 
 /// <summary>
 /// <para>


### PR DESCRIPTION
1.0.3 additional:
- Made it easier to navigate into the right file, thanks to a comment just before the generated type definition.
- Fixed a compile-time bug where [Wrapper]ValueObject inheritance combined with the IIdentity interface would cause an unwarranted warning.

Also:
- Ran code cleanup.