### PR TITLE
1.1.0: Semi-breaking: Generated types no longer add [Serializable] attribute

### DIFF
--- a/DomainModeling.Generator/IdentityGenerator.cs
+++ b/DomainModeling.Generator/IdentityGenerator.cs
@@ -196,9 +196,6 @@ public class IdentityGenerator : SourceGenerator
 					: method.ReturnType.IsType(nameof(Nullable<int>), "System") && method.ReturnType.HasSingleGenericTypeArgument(underlyingType)) &&
 				method.Parameters[0].Type.IsType(nameof(Nullable<int>), "System") && method.Parameters[0].Type.HasSingleGenericTypeArgument(type)));
 
-			existingComponents |= IdTypeComponents.SerializableAttribute.If(type.GetAttributes().Any(attribute =>
-				attribute.AttributeClass?.IsType<SerializableAttribute>() == true));
-
 			existingComponents |= IdTypeComponents.SystemTextJsonConverter.If(type.GetAttributes().Any(attribute =>
 				attribute.AttributeClass?.IsType("JsonConverterAttribute", "System.Text.Json.Serialization") == true));
 
@@ -295,11 +292,6 @@ using {Constants.DomainModelingNamespace};
 
 namespace {containingNamespace}
 {{
-	{summary}
-	{(existingComponents.HasFlags(IdTypeComponents.SerializableAttribute) ? "/*" : "")}
-	[Serializable]
-	{(existingComponents.HasFlags(IdTypeComponents.SerializableAttribute) ? "*/" : "")}
-
 	{(existingComponents.HasFlags(IdTypeComponents.SystemTextJsonConverter) ? "/*" : "")}
 	[System.Text.Json.Serialization.JsonConverter(typeof({idTypeName}.JsonConverter))]
 	{(existingComponents.HasFlags(IdTypeComponents.SystemTextJsonConverter) ? "*/" : "")}
@@ -492,10 +484,9 @@ namespace {containingNamespace}
 		ConvertFromOperator = 1 << 14,
 		NullableConvertToOperator = 1 << 15,
 		NullableConvertFromOperator = 1 << 16,
-		SerializableAttribute = 1 << 17,
-		NewtonsoftJsonConverter = 1 << 18,
-		SystemTextJsonConverter = 1 << 19,
-		StringComparison = 1 << 20,
+		NewtonsoftJsonConverter = 1 << 17,
+		SystemTextJsonConverter = 1 << 18,
+		StringComparison = 1 << 19,
 	}
 
 	private sealed record Generatable : IGeneratable

--- a/DomainModeling.Generator/ValueObjectGenerator.cs
+++ b/DomainModeling.Generator/ValueObjectGenerator.cs
@@ -133,9 +133,6 @@ public class ValueObjectGenerator : SourceGenerator
 			method.Parameters[0].Type.Equals(type, SymbolEqualityComparer.Default) &&
 			method.Parameters[1].Type.Equals(type, SymbolEqualityComparer.Default)));
 
-		existingComponents |= ValueObjectTypeComponents.SerializableAttribute.If(type.GetAttributes().Any(attribute =>
-			attribute.AttributeClass?.IsType<SerializableAttribute>() == true));
-
 		existingComponents |= ValueObjectTypeComponents.StringComparison.If(members.Any(member =>
 			member.Name == "StringComparison" && member.IsOverride));
 
@@ -248,10 +245,6 @@ using {Constants.DomainModelingNamespace};
 
 namespace {containingNamespace}
 {{
-	{(existingComponents.HasFlags(ValueObjectTypeComponents.SerializableAttribute) ? "/*" : "")}
-	[Serializable]
-	{(existingComponents.HasFlags(ValueObjectTypeComponents.SerializableAttribute) ? "*/" : "")}
-
 	/* Generated */ {type.DeclaredAccessibility.ToCodeString()} sealed partial {(isRecord ? "record" : "class")} {typeName} : IEquatable<{typeName}>{(isComparable ? "" : "/*")}, IComparable<{typeName}>{(isComparable ? "" : "*/")}
 	{{
 		{(isRecord || existingComponents.HasFlags(ValueObjectTypeComponents.StringComparison) ? "/*" : "")}
@@ -377,8 +370,7 @@ namespace {containingNamespace}
 		LessThanOperator = 1 << 10,
 		GreaterEqualsOperator = 1 << 11,
 		LessEqualsOperator = 1 << 12,
-		SerializableAttribute = 1 << 13,
-		StringComparison = 1 << 14,
+		StringComparison = 1 << 13,
 	}
 
 	private sealed record Generatable : IGeneratable

--- a/DomainModeling.Generator/WrapperValueObjectGenerator.cs
+++ b/DomainModeling.Generator/WrapperValueObjectGenerator.cs
@@ -143,9 +143,6 @@ public class WrapperValueObjectGenerator : SourceGenerator
 			method.ReturnType.IsType(nameof(Nullable<int>), "System") && method.ReturnType.HasSingleGenericTypeArgument(underlyingType) &&
 			method.Parameters[0].Type.Equals(type, SymbolEqualityComparer.Default)));
 
-		existingComponents |= WrapperValueObjectTypeComponents.SerializableAttribute.If(type.GetAttributes().Any(attribute =>
-			attribute.AttributeClass?.IsType<SerializableAttribute>() == true));
-
 		existingComponents |= WrapperValueObjectTypeComponents.SystemTextJsonConverter.If(type.GetAttributes().Any(attribute =>
 			attribute.AttributeClass?.IsType("JsonConverterAttribute", "System.Text.Json.Serialization") == true));
 
@@ -210,10 +207,6 @@ using {Constants.DomainModelingNamespace};
 
 namespace {containingNamespace}
 {{
-	{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.SerializableAttribute) ? "/*" : "")}
-	[Serializable]
-	{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.SerializableAttribute) ? "*/" : "")}
-
 	{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.SystemTextJsonConverter) ? "/*" : "")}
 	[System.Text.Json.Serialization.JsonConverter(typeof({typeName}.JsonConverter))]
 	{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.SystemTextJsonConverter) ? "*/" : "")}
@@ -402,10 +395,9 @@ namespace {containingNamespace}
 		ConvertFromOperator = 1 << 14,
 		NullableConvertToOperator = 1 << 15,
 		NullableConvertFromOperator = 1 << 16,
-		SerializableAttribute = 1 << 17,
-		NewtonsoftJsonConverter = 1 << 18,
-		SystemTextJsonConverter = 1 << 19,
-		StringComparison = 1 << 20,
+		NewtonsoftJsonConverter = 1 << 17,
+		SystemTextJsonConverter = 1 << 18,
+		StringComparison = 1 << 19,
 	}
 
 	private sealed record Generatable : IGeneratable

--- a/DomainModeling.Tests/IdentityTests.cs
+++ b/DomainModeling.Tests/IdentityTests.cs
@@ -486,7 +486,6 @@ namespace Architect.DomainModeling.Tests
 		/// </summary>
 		[Obsolete("Should merely compile.", error: true)]
 		[SourceGenerated]
-		[Serializable]
 		[System.Text.Json.Serialization.JsonConverter(typeof(JsonConverter))]
 		[Newtonsoft.Json.JsonConverter(typeof(NewtonsoftJsonConverter))]
 		internal readonly partial struct FullySelfImplementedIdentity : IIdentity<int>, IEquatable<FullySelfImplementedIdentity>, IComparable<FullySelfImplementedIdentity>

--- a/DomainModeling.Tests/WrapperValueObjectTests.cs
+++ b/DomainModeling.Tests/WrapperValueObjectTests.cs
@@ -484,7 +484,6 @@ namespace Architect.DomainModeling.Tests
 		/// </summary>
 		[Obsolete("Should merely compile.", error: true)]
 		[SourceGenerated]
-		[Serializable]
 		[System.Text.Json.Serialization.JsonConverter(typeof(JsonConverter))]
 		[Newtonsoft.Json.JsonConverter(typeof(NewtonsoftJsonConverter))]
 		internal sealed partial class FullySelfImplementedWrapperValueObject : WrapperValueObject<int>, IComparable<FullySelfImplementedWrapperValueObject>

--- a/DomainModeling/DomainModeling.csproj
+++ b/DomainModeling/DomainModeling.csproj
@@ -18,13 +18,16 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix>1.0.3</VersionPrefix>
+		<VersionPrefix>1.1.0</VersionPrefix>
 		<Description>
 A complete Domain-Driven Design (DDD) toolset for implementing domain models, including base types and source generators.
 
 https://github.com/TheArchitectDev/Architect.DomainModeling
 
 Release notes:
+
+1.1.0:
+- Semi-breaking: Generated types no longer add [Serializable] attribute, since there would be no way to remove it.
 
 1.0.3:
 - Improved performance by using incremental generators.

--- a/DomainModeling/DomainObject.cs
+++ b/DomainModeling/DomainObject.cs
@@ -1,4 +1,4 @@
-﻿namespace Architect.DomainModeling;
+namespace Architect.DomainModeling;
 
 /// <summary>
 /// An object in the domain model.

--- a/DomainModeling/WrapperValueObject.cs
+++ b/DomainModeling/WrapperValueObject.cs
@@ -1,4 +1,4 @@
-﻿namespace Architect.DomainModeling;
+namespace Architect.DomainModeling;
 
 /// <summary>
 /// <para>


### PR DESCRIPTION
1.1.0: Semi-breaking: Generated types no longer add [Serializable] attribute, since there would be no way to remove it.