### PR TITLE
Fixed a warning and upgraded Example and Test projects to net7.

### DIFF
--- a/DomainModeling.Example/DomainModeling.Example.csproj
+++ b/DomainModeling.Example/DomainModeling.Example.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<AssemblyName>Architect.DomainModeling.Example</AssemblyName>
 		<RootNamespace>Architect.DomainModeling.Example</RootNamespace>
 		<Nullable>Enable</Nullable>

--- a/DomainModeling.Tests/DomainModeling.Tests.csproj
+++ b/DomainModeling.Tests/DomainModeling.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<AssemblyName>Architect.DomainModeling.Tests</AssemblyName>
 		<RootNamespace>Architect.DomainModeling.Tests</RootNamespace>
 		<ImplicitUsings>Enable</ImplicitUsings>

--- a/DomainModeling.Tests/DummyBuilderTests.cs
+++ b/DomainModeling.Tests/DummyBuilderTests.cs
@@ -174,7 +174,6 @@ namespace Architect.DomainModeling.Tests
 			}
 		}
 
-		[SourceGenerated]
 		public sealed partial class StringWrapperTestingEntity : Entity<int>
 		{
 			public StringWrapper FirstName { get; }

--- a/DomainModeling.Tests/IdentityTests.cs
+++ b/DomainModeling.Tests/IdentityTests.cs
@@ -534,9 +534,9 @@ namespace Architect.DomainModeling.Tests
 			public static implicit operator FullySelfImplementedIdentity(int value) => new FullySelfImplementedIdentity(value);
 			public static implicit operator int(FullySelfImplementedIdentity id) => id.Value;
 
-			[return: NotNullIfNotNull("value")]
+			[return: NotNullIfNotNull(nameof(value))]
 			public static implicit operator FullySelfImplementedIdentity?(int? value) => value is null ? null : new FullySelfImplementedIdentity(value.Value);
-			[return: NotNullIfNotNull("id")]
+			[return: NotNullIfNotNull(nameof(id))]
 			public static implicit operator int?(FullySelfImplementedIdentity? id) => id?.Value;
 
 			private sealed class JsonConverter : System.Text.Json.Serialization.JsonConverter<FullySelfImplementedIdentity>

--- a/DomainModeling.Tests/WrapperValueObjectTests.cs
+++ b/DomainModeling.Tests/WrapperValueObjectTests.cs
@@ -541,7 +541,7 @@ namespace Architect.DomainModeling.Tests
 			public static explicit operator FullySelfImplementedWrapperValueObject(int value) => new FullySelfImplementedWrapperValueObject(value);
 			public static implicit operator int([DisallowNull] FullySelfImplementedWrapperValueObject instance) => instance.Value;
 
-			[return: MaybeNull, NotNullIfNotNull("value")]
+			[return: MaybeNull, NotNullIfNotNull(nameof(value))]
 			public static explicit operator FullySelfImplementedWrapperValueObject(int? value) => value is null ? null : new FullySelfImplementedWrapperValueObject(value.Value);
 			public static implicit operator int?([AllowNull] FullySelfImplementedWrapperValueObject id) => id?.Value;
 


### PR DESCRIPTION
- Fixed a warning in a test, caused by a useless [SourceGenerated] attribute.
- Upgraded Example and Test projects to net7, and fixed new analyzer warnings.