### PR TITLE
Serializing as property names, and other serialization and ToString() improvements.

### DIFF
--- a/DomainModeling.Generator/DomainModeling.Generator.csproj
+++ b/DomainModeling.Generator/DomainModeling.Generator.csproj
@@ -6,7 +6,7 @@
 		<RootNamespace>Architect.DomainModeling.Generator</RootNamespace>
 		<Nullable>Enable</Nullable>
 		<ImplicitUsings>Enable</ImplicitUsings>
-		<LangVersion>10</LangVersion>
+		<LangVersion>11</LangVersion>
 		<IsPackable>False</IsPackable>
 		<DevelopmentDependency>True</DevelopmentDependency>
 	</PropertyGroup>

--- a/DomainModeling.Generator/WrapperValueObjectGenerator.cs
+++ b/DomainModeling.Generator/WrapperValueObjectGenerator.cs
@@ -392,8 +392,10 @@ namespace {containingNamespace}
 
 			public override void WriteJson(Newtonsoft.Json.JsonWriter writer, [AllowNull] object value, Newtonsoft.Json.JsonSerializer serializer)
 			{{
-				if (value is null) serializer.Serialize(writer, null);
-				else serializer.Serialize(writer, (({typeName})value).Value);
+				if (value is null)
+					serializer.Serialize(writer, null);
+				else
+					serializer.Serialize(writer, (({typeName})value).Value);
 			}}
 
 			[return: MaybeNull]

--- a/DomainModeling.Tests/Entities/Entity.SourceGeneratedIdentityTests.cs
+++ b/DomainModeling.Tests/Entities/Entity.SourceGeneratedIdentityTests.cs
@@ -346,6 +346,10 @@ public class SourceGeneratedIdentityTests
 	public void DeserializeWithSystemTextJson_Regularly_ShouldReturnExpectedResult(string json, int? value)
 	{
 		Assert.Equal(value, System.Text.Json.JsonSerializer.Deserialize<IntId?>(json)?.Value);
+		if (value is null)
+			Assert.Throws<System.Text.Json.JsonException>(() => System.Text.Json.JsonSerializer.Deserialize<IntId>(json));
+		else
+			Assert.Equal(value, System.Text.Json.JsonSerializer.Deserialize<IntId>(json).Value);
 
 		json = json == "null" ? json : $@"""{json}""";
 		Assert.Equal(value?.ToString(), System.Text.Json.JsonSerializer.Deserialize<StringId?>(json)?.Value);
@@ -359,6 +363,10 @@ public class SourceGeneratedIdentityTests
 	public void DeserializeWithNewtonsoftJson_Regularly_ShouldReturnExpectedResult(string json, int? value)
 	{
 		Assert.Equal(value, Newtonsoft.Json.JsonConvert.DeserializeObject<IntId?>(json)?.Value);
+		if (value is null)
+			Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => Newtonsoft.Json.JsonConvert.DeserializeObject<IntId>(json));
+		else
+			Assert.Equal(value, Newtonsoft.Json.JsonConvert.DeserializeObject<IntId>(json).Value);
 
 		json = json == "null" ? json : $@"""{json}""";
 		Assert.Equal(value?.ToString(), Newtonsoft.Json.JsonConvert.DeserializeObject<StringId?>(json)?.Value);
@@ -382,7 +390,7 @@ public class SourceGeneratedIdentityTests
 		CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("nl-NL");
 
 		if (value is null)
-			Assert.Throws<ArgumentNullException>(() => System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json));
+			Assert.Throws<System.Text.Json.JsonException>(() => System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json));
 		else
 			Assert.Equal(value.Value, System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json).Value);
 	}
@@ -404,7 +412,7 @@ public class SourceGeneratedIdentityTests
 		CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("nl-NL");
 
 		if (value is null)
-			Assert.Throws<ArgumentNullException>(() => Newtonsoft.Json.JsonConvert.DeserializeObject<DecimalId>(json));
+			Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => Newtonsoft.Json.JsonConvert.DeserializeObject<DecimalId>(json));
 		else
 			Assert.Equal(value.Value, Newtonsoft.Json.JsonConvert.DeserializeObject<DecimalId>(json).Value);
 	}

--- a/DomainModeling/Conversions/FormattingExtensions.cs
+++ b/DomainModeling/Conversions/FormattingExtensions.cs
@@ -1,0 +1,30 @@
+namespace Architect.DomainModeling.Conversions;
+
+/// <summary>
+/// Provides formatting-related extension methods on formattable types.
+/// </summary>
+public static class FormattingExtensions
+{
+#if NET7_0_OR_GREATER
+	/// <summary>
+	/// <para>
+	/// Formats the <paramref name="value"/> into the provided <paramref name="buffer"/>, returning the segment that was written to.
+	/// </para>
+	/// <para>
+	/// If there is not enough space in the <paramref name="buffer"/>, instead a new string is allocated and returned as a span.
+	/// </para>
+	/// </summary>
+	/// <param name="value">The value to format.</param>
+	/// <param name="buffer">The buffer to attempt to format into. For best performance, it is advisable to use a stack-allocated buffer that is expected to be large enough, e.g. 64 chars.</param>
+	/// <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format.</param>
+	/// <param name="provider">An optional object that supplies culture-specific formatting information.</param>
+	public static ReadOnlySpan<char> Format<T>(this T value, Span<char> buffer, ReadOnlySpan<char> format, IFormatProvider? provider)
+		where T : notnull, ISpanFormattable
+	{
+		if (!value.TryFormat(buffer, out var charCount, format, provider))
+			return value.ToString().AsSpan();
+
+		return buffer[..charCount];
+	}
+#endif
+}

--- a/DomainModeling/Conversions/Utf8JsonReaderExtensions.cs
+++ b/DomainModeling/Conversions/Utf8JsonReaderExtensions.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+
+namespace Architect.DomainModeling.Conversions;
+
+/// <summary>
+/// Provides conversion-related extension methods on <see cref="Utf8JsonReader"/>.
+/// </summary>
+public static class Utf8JsonReaderExtensions
+{
+#if NET7_0_OR_GREATER
+	/// <summary>
+	/// Reads the next string JSON token from the source and parses it as <typeparamref name="T"/>, which must implement <see cref="ISpanParsable{TSelf}"/>.
+	/// </summary>
+	/// <param name="reader">A <see cref="Utf8JsonReader"/> that is ready to read a property name.</param>
+	/// <param name="provider">An object that provides culture-specific formatting information about the input string.</param>
+	public static T GetParsedString<T>(this Utf8JsonReader reader, IFormatProvider? provider)
+		where T : ISpanParsable<T>
+	{
+		ReadOnlySpan<char> chars = stackalloc char[0];
+
+		var maxCharLength = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+		if (maxCharLength > 2048) // Avoid oversized stack allocations
+		{
+			chars = reader.GetString().AsSpan();
+		}
+		else
+		{
+			Span<char> buffer = stackalloc char[(int)maxCharLength];
+			var charCount = reader.CopyString(buffer);
+			chars = buffer[..charCount];
+		}
+
+		var result = T.Parse(chars, provider);
+		return result;
+	}
+#endif
+}

--- a/DomainModeling/DomainModeling.csproj
+++ b/DomainModeling/DomainModeling.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>net7.0;net6.0;net5.0</TargetFrameworks>
 		<AssemblyName>Architect.DomainModeling</AssemblyName>
 		<RootNamespace>Architect.DomainModeling</RootNamespace>
 		<Nullable>Enable</Nullable>
 		<ImplicitUsings>Enable</ImplicitUsings>
-		<LangVersion>10</LangVersion>
+		<LangVersion>11</LangVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<IsTrimmable>True</IsTrimmable>
 	</PropertyGroup>
@@ -23,13 +23,17 @@ Release notes:
 2.0.0:
 - BREAKING: Generated DummyBuilders now use UTC datetimes for generated defaults and for interpreting datetime strings.
 - Semi-breaking: Generated types no longer add [Serializable] attribute, since there would be no way to remove it.
-- Fixed a compile-time bug where the source generator for ValueObjects would create non-compiling equality/comparisons for properties of types created solely by source generators.
-- Fixed a potential bug in Entity&lt;TId&gt;, where entities of different types could be considered equal if they used the same TId (which they should not).
 - Identity and WrapperValueObject&lt;TValue&gt; types now honor the underlying type's nullability in ToString().
+- Identity and WrapperValueObject&lt;TValue&gt; types' generated System.Text.Json serializers now implement ReadAsPropertyName() and WriteAsPropertyName(), enabling serialization of such types when they are used as dictionary keys (only in .NET 7 and up).
+- DummyBuilderGenerator: WrapperValueObject&lt;string&gt; and IIdentity&lt;string&gt; constructor params now get a string value equal to the param name instead of the type name (e.g. "FirstName" and "LastName" instead of "ProperName" and "ProperName").
 - Added some missing nullable annotations.
+- Identity types now serialize additional large numeric types as string, to avoid JavaScript overflows: UInt128 and Int128.
 - Identity types generated for Entity&lt;TId, TIdPrimitive&gt; now have a summary.
 - Identity types wrapping a non-nullable string now explain the non-nullness for default struct instances, in summaries for ToString(), Value, and convert-to-string operators.
-- DummyBuilderGenerator: WrapperValueObject&lt;string&gt; and IIdentity&lt;string&gt; constructor params now get a string value equal to the param name instead of the type name (e.g. "FirstName" and "LastName" instead of "ProperName" and "ProperName").
+- Identity types: Fixed a bug where string representations of numeric IDs could contain meaningless decimal places, e.g. when a decimal was internally represented as 1.0.
+- Identity types: Fixed a bug in the generated JSON converters for IIdentity&lt;decimal&gt;, where an incorrect ArgumentNullException or NullReferenceException could be thrown instead of the expected JsonException/JsonSerializationException.
+- Fixed a compile-time bug where the source generator for ValueObjects would create non-compiling equality/comparison for properties of types created solely by source generators.
+- Fixed a potential bug in Entity&lt;TId&gt;, where entities of different types could be considered equal if they used the same TId (even though the latter is not advisable).
 - Added support for trimming.
 - Minor performance optimizations.
 


### PR DESCRIPTION
- Identity and WrapperValueObject&lt;TValue&gt; types' generated System.Text.Json serializers now implement ReadAsPropertyName() and WriteAsPropertyName(), enabling serialization of such types when they are used as dictionary keys (only in .NET 7 and up).
- Identity types now serialize additional large numeric types as string, to avoid JavaScript overflows: UInt128 and Int128.
- Identity types: Fixed a bug where string representations of numeric IDs could contain meaningless decimal places, e.g. when a decimal was internally represented as 1.0.
- Identity types: Fixed a bug in the generated JSON converters for IIdentity&lt;decimal&gt;, where an incorrect ArgumentNullException or NullReferenceException could be thrown instead of the expected JsonException/JsonSerializationException.