### PR TITLE
Nullables.

### DIFF
--- a/DomainModeling.Generator/DomainModeling.Generator.csproj
+++ b/DomainModeling.Generator/DomainModeling.Generator.csproj
@@ -9,6 +9,7 @@
 		<LangVersion>11</LangVersion>
 		<IsPackable>False</IsPackable>
 		<DevelopmentDependency>True</DevelopmentDependency>
+		<EnforceExtendedAnalyzerRules>True</EnforceExtendedAnalyzerRules>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -17,11 +18,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
 	</ItemGroup>
 
 </Project>

--- a/DomainModeling.Generator/DummyBuilderGenerator.cs
+++ b/DomainModeling.Generator/DummyBuilderGenerator.cs
@@ -260,6 +260,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
+#nullable disable
+
 namespace {containingNamespace}
 {{
 	/// <summary>
@@ -273,8 +275,6 @@ namespace {containingNamespace}
 	/// </summary>
 	/* Generated */ public partial class {typeName}
 	{{
-#nullable disable
-
 {joinedComponents}
 
 		{(hasBuildMethod ? "/*" : "")}

--- a/DomainModeling.Generator/IdentityGenerator.cs
+++ b/DomainModeling.Generator/IdentityGenerator.cs
@@ -339,6 +339,8 @@ using System.Diagnostics.CodeAnalysis;
 using {Constants.DomainModelingNamespace};
 using {Constants.DomainModelingNamespace}.Conversions;
 
+#nullable enable
+
 namespace {containingNamespace}
 {{
 	{summary}
@@ -356,13 +358,12 @@ namespace {containingNamespace}
 	{{
 		{(existingComponents.HasFlags(IdTypeComponents.Value) ? "/*" : "")}
 		{nonNullStringSummary}
-		{(underlyingType.IsValueType ? "" : isNonNullString ? "[NotNull]" : "[AllowNull, MaybeNull]")}
-		public {underlyingTypeFullyQualifiedName} Value {(isNonNullString ? @"=> this._value ?? """";" : "{ get; }")}
+		public {underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType ? "" : isNonNullString ? "" : "?")} Value {(isNonNullString ? @"=> this._value ?? """";" : "{ get; }")}
 		{(isNonNullString ? "private readonly string _value;" : "")}
 		{(existingComponents.HasFlags(IdTypeComponents.Value) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.Constructor) ? "/*" : "")}
-		public {idTypeName}({(underlyingType.IsValueType ? "" : "[AllowNull] ")}{underlyingTypeFullyQualifiedName} value)
+		public {idTypeName}({underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType ? "" : "?")} value)
 		{{
 			{(isNonNullString ? @"this._value = value ?? """";" : "this.Value = value;")}
 		}}
@@ -375,8 +376,7 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(IdTypeComponents.StringComparison) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.ToStringOverride) ? "/*" : "")}{nonNullStringSummary}
-		{(isNonNullString || !isToStringNullable ? "[return: NotNull]" : "[return: MaybeNull]")}
-		public override string ToString()
+		public override string{(isNonNullString || !isToStringNullable ? "" : "?")} ToString()
 		{{
 
 			return {(underlyingType.IsOrImplementsInterface(interf => interf.Name == "INumber" && interf.ContainingNamespace.HasFullName("System.Numerics") && interf.Arity == 1, out _)
@@ -395,7 +395,7 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(IdTypeComponents.GetHashCodeOverride) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.EqualsOverride) ? "/*" : "")}
-		public override bool Equals([AllowNull] object other)
+		public override bool Equals(object? other)
 		{{
 			return other is {idTypeName} otherId && this.Equals(otherId);
 		}}
@@ -436,22 +436,21 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(IdTypeComponents.LessEqualsOperator) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.ConvertToOperator) ? "/*" : "")}
-		public static implicit operator {idTypeName}({(underlyingType.IsValueType ? "" : "[AllowNull] ")}{underlyingTypeFullyQualifiedName} value) => new {idTypeName}(value);
+		public static implicit operator {idTypeName}({underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType ? "" : "?")} value) => new {idTypeName}(value);
 		{(existingComponents.HasFlags(IdTypeComponents.ConvertToOperator) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.ConvertFromOperator) ? "/*" : "")}{nonNullStringSummary}
-		{(underlyingType.IsValueType ? "" : isNonNullString ? "[return: NotNull]" : "[return: MaybeNull]")}
-		public static implicit operator {underlyingTypeFullyQualifiedName}({idTypeName} id) => id.Value;
+		public static implicit operator {underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType || isNonNullString ? "" : "?")}({idTypeName} id) => id.Value;
 		{(existingComponents.HasFlags(IdTypeComponents.ConvertFromOperator) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.NullableConvertToOperator) ? "/*" : "")}
-		[return: MaybeNull, NotNullIfNotNull(""value"")]
-		public static implicit operator {idTypeName}?({(underlyingType.IsValueType ? "" : "[AllowNull] ")}{underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType ? "?" : "")} value) => value is null ? ({idTypeName}?)null : new {idTypeName}(value{(underlyingType.IsValueType ? ".Value" : "")});
+		[return: NotNullIfNotNull(""value"")]
+		public static implicit operator {idTypeName}?({underlyingTypeFullyQualifiedName}? value) => value is null ? ({idTypeName}?)null : new {idTypeName}(value{(underlyingType.IsValueType ? ".Value" : "")});
 		{(existingComponents.HasFlags(IdTypeComponents.NullableConvertToOperator) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.NullableConvertFromOperator) ? "/*" : "")}{nonNullStringSummary}
-		{(underlyingType.IsValueType || isNonNullString ? @"[return: MaybeNull, NotNullIfNotNull(""id"")]" : "[return: MaybeNull]")}
-		public static implicit operator {underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType ? "?" : "")}({idTypeName}? id) => id?.Value;
+		{(underlyingType.IsValueType || isNonNullString ? @"[return: NotNullIfNotNull(""id"")]" : "")}
+		public static implicit operator {underlyingTypeFullyQualifiedName}?({idTypeName}? id) => id?.Value;
 		{(existingComponents.HasFlags(IdTypeComponents.NullableConvertFromOperator) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(IdTypeComponents.SystemTextJsonConverter) ? "/*" : "")}
@@ -460,19 +459,17 @@ namespace {containingNamespace}
 			public override {idTypeName} Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
 			{{
 				{longNumericTypeComment}
-				#nullable disable
 				{(underlyingTypeIsNumericUnsuitableForJson
-				? longNumericTypeParseStatement
-				: $@"return ({idTypeName})System.Text.Json.JsonSerializer.Deserialize<{underlyingTypeFullyQualifiedName}>(ref reader, options);")}
-				#nullable enable
+					? longNumericTypeParseStatement
+					: $@"return ({idTypeName})System.Text.Json.JsonSerializer.Deserialize<{underlyingTypeFullyQualifiedName}>(ref reader, options);")}
 			}}
 
-			public override void Write(System.Text.Json.Utf8JsonWriter writer, [AllowNull] {idTypeName} value, System.Text.Json.JsonSerializerOptions options)
+			public override void Write(System.Text.Json.Utf8JsonWriter writer, {idTypeName} value, System.Text.Json.JsonSerializerOptions options)
 			{{
 				{longNumericTypeComment}
 				{(underlyingTypeIsNumericUnsuitableForJson
-				? longNumericTypeFormatStatement
-				: "System.Text.Json.JsonSerializer.Serialize(writer, value.Value, options);")}
+					? longNumericTypeFormatStatement
+					: "System.Text.Json.JsonSerializer.Serialize(writer, value.Value, options);")}
 			}}
 
 			{readAndWriteAsPropertyNameMethods}
@@ -487,7 +484,7 @@ namespace {containingNamespace}
 				return objectType == typeof({idTypeName}) || objectType == typeof({idTypeName}?);
 			}}
 
-			public override void WriteJson(Newtonsoft.Json.JsonWriter writer, [AllowNull] object value, Newtonsoft.Json.JsonSerializer serializer)
+			public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)
 			{{
 				{longNumericTypeComment}
 				if (value is null)
@@ -498,20 +495,17 @@ namespace {containingNamespace}
 						: $"serializer.Serialize(writer, (({idTypeName})value).Value);")}
 			}}
 
-			[return: MaybeNull]
-			public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, [AllowNull] object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+			public override object? ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)
 			{{
 				{longNumericTypeComment}
-				#nullable disable
 				if (objectType == typeof({idTypeName})) // Non-nullable
 					{(underlyingTypeIsNumericUnsuitableForJson
-					? $@"return reader.TokenType == Newtonsoft.Json.JsonToken.String ? ({idTypeName}){underlyingType.ContainingNamespace}.{underlyingType.Name}.Parse(serializer.Deserialize<string>(reader), System.Globalization.CultureInfo.InvariantCulture) : ({idTypeName})serializer.Deserialize<{underlyingTypeFullyQualifiedName}>(reader);"
-					: $@"return ({idTypeName})serializer.Deserialize<{underlyingTypeFullyQualifiedName}>(reader);")}
+						? $@"return reader.TokenType == Newtonsoft.Json.JsonToken.String ? ({idTypeName}){underlyingType.ContainingNamespace}.{underlyingType.Name}.Parse(serializer.Deserialize<string>(reader)!, System.Globalization.CultureInfo.InvariantCulture) : ({idTypeName})serializer.Deserialize<{underlyingTypeFullyQualifiedName}>(reader);"
+						: $@"return ({idTypeName})serializer.Deserialize<{underlyingTypeFullyQualifiedName}>(reader);")}
 				else // Nullable
 					{(underlyingTypeIsNumericUnsuitableForJson
-					? $@"return reader.TokenType == Newtonsoft.Json.JsonToken.String ? ({idTypeName}?){underlyingType.ContainingNamespace}.{underlyingType.Name}.Parse(serializer.Deserialize<string>(reader), System.Globalization.CultureInfo.InvariantCulture) : ({idTypeName}?)serializer.Deserialize<{underlyingTypeFullyQualifiedName}?>(reader);"
-					: $@"return ({idTypeName}?)serializer.Deserialize<{underlyingTypeFullyQualifiedName}{(underlyingType.IsValueType ? "?" : "")}>(reader);")}
-				#nullable enable
+						? $@"return reader.TokenType == Newtonsoft.Json.JsonToken.String ? ({idTypeName}?){underlyingType.ContainingNamespace}.{underlyingType.Name}.Parse(serializer.Deserialize<string>(reader)!, System.Globalization.CultureInfo.InvariantCulture) : ({idTypeName}?)serializer.Deserialize<{underlyingTypeFullyQualifiedName}?>(reader);"
+						: $@"return ({idTypeName}?)serializer.Deserialize<{underlyingTypeFullyQualifiedName}?>(reader);")}
 			}}
 		}}
 		{(existingComponents.HasFlags(IdTypeComponents.NewtonsoftJsonConverter) ? "*/" : "")}

--- a/DomainModeling.Generator/IncrementalValueProviderExtensions.cs
+++ b/DomainModeling.Generator/IncrementalValueProviderExtensions.cs
@@ -7,7 +7,7 @@ namespace Architect.DomainModeling.Generator;
 /// </summary>
 internal static class IncrementalValueProviderExtensions
 {
-#nullable disable
+#nullable disable // LINQ-assisted null filtering is not yet detected by the compiler
 	/// <summary>
 	/// <para>
 	/// Deduplicates partials, preventing duplicate source generation.

--- a/DomainModeling.Generator/TypeSymbolExtensions.cs
+++ b/DomainModeling.Generator/TypeSymbolExtensions.cs
@@ -465,7 +465,7 @@ internal static class TypeSymbolExtensions
 	{
 		if (typeSymbol.IsValueType && !typeSymbol.IsNullable()) return $"this.{memberName}.ToString()";
 		if (typeSymbol.IsType<string>()) return String.Format(stringVariant, memberName);
-		return $"this.{memberName}?.ToString()";
+		return $"this.{memberName}?.ToString()"; // Null-safety can be especially relevant for instances created with FormatterServices.GetUninitializedObject()
 	}
 
 	/// <summary>

--- a/DomainModeling.Generator/ValueObjectGenerator.cs
+++ b/DomainModeling.Generator/ValueObjectGenerator.cs
@@ -243,6 +243,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using {Constants.DomainModelingNamespace};
 
+#nullable enable
+
 namespace {containingNamespace}
 {{
 	/* Generated */ {type.DeclaredAccessibility.ToCodeString()} sealed partial {(isRecord ? "record" : "class")} {typeName} : IEquatable<{typeName}>{(isComparable ? "" : "/*")}, IComparable<{typeName}>{(isComparable ? "" : "*/")}
@@ -254,7 +256,6 @@ namespace {containingNamespace}
 		{(isRecord || existingComponents.HasFlags(ValueObjectTypeComponents.StringComparison) ? "*/" : "")}
 
 		{(!isRecord && existingComponents.HasFlags(ValueObjectTypeComponents.ToStringOverride) ? "/*" : "")}
-		[return: NotNull]
 		public sealed override string ToString()
 		{{
 			{toStringBody}
@@ -271,14 +272,14 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.GetHashCodeOverride) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.EqualsOverride) ? "/*" : "")}
-		public sealed override bool Equals([AllowNull] object other)
+		public sealed override bool Equals(object? other)
 		{{
 			return other is {typeName} otherValue && this.Equals(otherValue);
 		}}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.EqualsOverride) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.EqualsMethod) ? "/*" : "")}
-		public bool Equals([AllowNull] {typeName} other)
+		public bool Equals({typeName}? other)
 		{{
 			if (other is null) return false;
 
@@ -298,7 +299,7 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.CompareToMethod) ? "/*" : "")}
 		{(isComparable ? "" : "/*")}
 		// This method is generated only if the ValueObject implements IComparable<T> against its own type and each data member implements IComparable<T> against its own type
-		public int CompareTo([AllowNull] {typeName} other)
+		public int CompareTo({typeName}? other)
 		{{
 			if (other is null) return +1;
 
@@ -316,31 +317,27 @@ namespace {containingNamespace}
 		{(isComparable ? "" : "*/")}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.CompareToMethod) ? "*/" : "")}
 
-		#nullable disable // The compiler fails to interpret nullable attributes on overloaded operators at the time of writing
-
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.EqualsOperator) ? "/*" : "")}
-		public static bool operator ==([AllowNull] {typeName} left, [AllowNull] {typeName} right) => left is null ? right is null : left.Equals(right);
+		public static bool operator ==({typeName}? left, {typeName}? right) => left is null ? right is null : left.Equals(right);
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.EqualsOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.NotEqualsOperator) ? "/*" : "")}
-		public static bool operator !=([AllowNull] {typeName} left, [AllowNull] {typeName} right) => !(left == right);
+		public static bool operator !=({typeName}? left, {typeName}? right) => !(left == right);
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.NotEqualsOperator) ? "*/" : "")}
 
 		{(isComparable ? "" : "/*")}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.GreaterThanOperator) ? "/*" : "")}
-		public static bool operator >([AllowNull] {typeName} left, [AllowNull] {typeName} right) => left is null ? false : left.CompareTo(right) > 0;
+		public static bool operator >({typeName}? left, {typeName}? right) => left is null ? false : left.CompareTo(right) > 0;
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.GreaterThanOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.LessThanOperator) ? "/*" : "")}
-		public static bool operator <([AllowNull] {typeName} left, [AllowNull] {typeName} right) => left is null ? right is not null : left.CompareTo(right) < 0;
+		public static bool operator <({typeName}? left, {typeName}? right) => left is null ? right is not null : left.CompareTo(right) < 0;
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.LessThanOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.GreaterEqualsOperator) ? "/*" : "")}
-		public static bool operator >=([AllowNull] {typeName} left, [AllowNull] {typeName} right) => !(left < right);
+		public static bool operator >=({typeName}? left, {typeName}? right) => !(left < right);
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.GreaterEqualsOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.LessEqualsOperator) ? "/*" : "")}
-		public static bool operator <=([AllowNull] {typeName} left, [AllowNull] {typeName} right) => !(left > right);
+		public static bool operator <=({typeName}? left, {typeName}? right) => !(left > right);
 		{(existingComponents.HasFlags(ValueObjectTypeComponents.LessEqualsOperator) ? "*/" : "")}
 		{(isComparable ? "" : "*/")}
-
-		#nullable enable // The compiler fails to interpret nullable attributes on overloaded operators at the time of writing
 	}}
 }}
 ";

--- a/DomainModeling.Generator/WrapperValueObjectGenerator.cs
+++ b/DomainModeling.Generator/WrapperValueObjectGenerator.cs
@@ -239,6 +239,8 @@ using System.Diagnostics.CodeAnalysis;
 using {Constants.DomainModelingNamespace};
 using {Constants.DomainModelingNamespace}.Conversions;
 
+#nullable enable
+
 namespace {containingNamespace}
 {{
 	{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.SystemTextJsonConverter) ? "/*" : "")}
@@ -256,22 +258,20 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.StringComparison) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.Value) ? "/*" : "")}
-		{(underlyingType.IsValueType ? "" : "[DisallowNull, NotNull]")}
 		public {underlyingTypeName} Value {{ get; }}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.Value) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.Constructor) ? "/*" : "")}
-		public {typeName}({(underlyingType.IsValueType ? "" : "[DisallowNull] ")}{underlyingTypeName} value)
+		public {typeName}({underlyingTypeName} value)
 		{{
 			this.Value = value{(underlyingType.IsValueType ? "" : " ?? throw new ArgumentNullException(nameof(value))")};
 		}}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.Constructor) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.ToStringOverride) ? "/*" : "")}
-		{(!isToStringNullable ? "[return: NotNull]" : "[return: MaybeNull]")}
-		public sealed override string ToString()
+		public sealed override string{(isToStringNullable ? "?" : "")} ToString()
 		{{
-			// Null-safety protects instances from FormatterServices.GetUninitializedObject()
+			{(underlyingType.CreateStringExpression("Value").Contains('?') ? "// Null-safety protects instances from FormatterServices.GetUninitializedObject()" : "")}
 			return {underlyingType.CreateStringExpression("Value")};
 		}}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.ToStringOverride) ? "*/" : "")}
@@ -287,14 +287,14 @@ namespace {containingNamespace}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.GetHashCodeOverride) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.EqualsOverride) ? "/*" : "")}
-		public sealed override bool Equals([AllowNull] object other)
+		public sealed override bool Equals(object? other)
 		{{
 			return other is {typeName} otherValue && this.Equals(otherValue);
 		}}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.EqualsOverride) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.EqualsMethod) ? "/*" : "")}
-		public bool Equals([AllowNull] {typeName} other)
+		public bool Equals({typeName}? other)
 		{{
 			return other is null
 				? false
@@ -304,7 +304,7 @@ namespace {containingNamespace}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.CompareToMethod) ? "/*" : "")}
 		{(isComparable ? "" : "/*")}
-		public int CompareTo([AllowNull] {typeName} other)
+		public int CompareTo({typeName}? other)
 		{{
 			return other is null
 				? +1
@@ -313,69 +313,59 @@ namespace {containingNamespace}
 		{(isComparable ? "" : "*/")}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.CompareToMethod) ? "*/" : "")}
 
-		#nullable disable // The compiler fails to interpret nullable attributes on overloaded operators at the time of writing
-
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.EqualsOperator) ? "/*" : "")}
-		public static bool operator ==([AllowNull] {typeName} left, [AllowNull] {typeName} right) => left is null ? right is null : left.Equals(right);
+		public static bool operator ==({typeName}? left, {typeName}? right) => left is null ? right is null : left.Equals(right);
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.EqualsOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.NotEqualsOperator) ? "/*" : "")}
-		public static bool operator !=([AllowNull] {typeName} left, [AllowNull] {typeName} right) => !(left == right);
+		public static bool operator !=({typeName}? left, {typeName}? right) => !(left == right);
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.NotEqualsOperator) ? "*/" : "")}
 
 		{(isComparable ? "" : "/*")}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.GreaterThanOperator) ? "/*" : "")}
-		public static bool operator >([AllowNull] {typeName} left, [AllowNull] {typeName} right) => left is null ? false : left.CompareTo(right) > 0;
+		public static bool operator >({typeName}? left, {typeName}? right) => left is null ? false : left.CompareTo(right) > 0;
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.GreaterThanOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.LessThanOperator) ? "/*" : "")}
-		public static bool operator <([AllowNull] {typeName} left, [AllowNull] {typeName} right) => left is null ? right is not null : left.CompareTo(right) < 0;
+		public static bool operator <({typeName}? left, {typeName}? right) => left is null ? right is not null : left.CompareTo(right) < 0;
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.LessThanOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.GreaterEqualsOperator) ? "/*" : "")}
-		public static bool operator >=([AllowNull] {typeName} left, [AllowNull] {typeName} right) => !(left < right);
+		public static bool operator >=({typeName}? left, {typeName}? right) => !(left < right);
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.GreaterEqualsOperator) ? "*/" : "")}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.LessEqualsOperator) ? "/*" : "")}
-		public static bool operator <=([AllowNull] {typeName} left, [AllowNull] {typeName} right) => !(left > right);
+		public static bool operator <=({typeName}? left, {typeName}? right) => !(left > right);
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.LessEqualsOperator) ? "*/" : "")}
 		{(isComparable ? "" : "*/")}
 
-		#nullable enable // The compiler fails to interpret nullable attributes on overloaded operators at the time of writing
-
 		{(underlyingType.TypeKind == TypeKind.Interface || existingComponents.HasFlags(WrapperValueObjectTypeComponents.ConvertToOperator) ? "/*" : "")}
-		{(underlyingType.IsValueType ? "[return: NotNull]" : @"[return: MaybeNull, NotNullIfNotNull(""value"")]")}
-		public static explicit operator {typeName}({(underlyingType.IsValueType ? "" : "[AllowNull] ")}{underlyingTypeName} value) => {(underlyingType.IsValueType ? "" : "value is null ? null : ")}new {typeName}(value);
+		{(underlyingType.IsValueType ? "" : @"[return: NotNullIfNotNull(""value"")]")}
+		public static explicit operator {typeName}{(underlyingType.IsValueType ? "" : "?")}({underlyingTypeName}{(underlyingType.IsValueType ? "" : "?")} value) => {(underlyingType.IsValueType ? "" : "value is null ? null : ")}new {typeName}(value);
 		{(underlyingType.TypeKind == TypeKind.Interface || existingComponents.HasFlags(WrapperValueObjectTypeComponents.ConvertToOperator) ? "*/" : "")}
 
 		{(underlyingType.TypeKind == TypeKind.Interface || existingComponents.HasFlags(WrapperValueObjectTypeComponents.ConvertFromOperator) ? "/*" : "")}
-		{(underlyingType.IsValueType ? "" : @"[return: MaybeNull, NotNullIfNotNull(""instance"")]")}
-		public static implicit operator {underlyingTypeName}({(underlyingType.IsValueType ? "[DisallowNull] " : "[AllowNull] ")}{typeName} instance) => instance{(underlyingType.IsValueType ? "" : "?")}.Value;
+		{(underlyingType.IsValueType ? "" : @"[return: NotNullIfNotNull(""instance"")]")}
+		public static implicit operator {underlyingTypeName}{(underlyingType.IsValueType ? "" : "?")}({typeName}{(underlyingType.IsValueType ? "" : "?")} instance) => instance{(underlyingType.IsValueType ? "" : "?")}.Value;
 		{(underlyingType.TypeKind == TypeKind.Interface || existingComponents.HasFlags(WrapperValueObjectTypeComponents.ConvertFromOperator) ? "*/" : "")}
 
 		{(underlyingType.IsNullable() || existingComponents.HasFlags(WrapperValueObjectTypeComponents.NullableConvertToOperator) ? "/*" : "")}
-		{(underlyingType.IsValueType ? @"[return: MaybeNull, NotNullIfNotNull(""value"")]" : "")}
-		{(underlyingType.IsValueType ? $"public static explicit operator {typeName}({underlyingTypeName}? value) => value is null ? null : new {typeName}(value.Value);" : "")}
+		{(underlyingType.IsValueType ? @"[return: NotNullIfNotNull(""value"")]" : "")}
+		{(underlyingType.IsValueType ? $"public static explicit operator {typeName}?({underlyingTypeName}? value) => value is null ? null : new {typeName}(value.Value);" : "")}
 		{(underlyingType.IsNullable() || existingComponents.HasFlags(WrapperValueObjectTypeComponents.NullableConvertToOperator) ? "*/" : "")}
 
 		{(underlyingType.IsNullable() || existingComponents.HasFlags(WrapperValueObjectTypeComponents.NullableConvertFromOperator) ? "/*" : "")}
-		{(underlyingType.IsValueType ? @"[return: MaybeNull, NotNullIfNotNull(""instance"")]" : "")}
-		{(underlyingType.IsValueType ? $"public static implicit operator {underlyingTypeName}?([AllowNull] {typeName} instance) => instance?.Value;" : "")}
+		{(underlyingType.IsValueType ? @"[return: NotNullIfNotNull(""instance"")]" : "")}
+		{(underlyingType.IsValueType ? $"public static implicit operator {underlyingTypeName}?({typeName}? instance) => instance?.Value;" : "")}
 		{(underlyingType.IsNullable() || existingComponents.HasFlags(WrapperValueObjectTypeComponents.NullableConvertFromOperator) ? "*/" : "")}
 
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.SystemTextJsonConverter) ? "/*" : "")}
 		private sealed class JsonConverter : System.Text.Json.Serialization.JsonConverter<{typeName}>
 		{{
-			[return: MaybeNull]
 			public override {typeName} Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
 			{{
-				#nullable disable
-				return ({typeName})System.Text.Json.JsonSerializer.Deserialize<{underlyingTypeName}{(underlyingType.IsValueType ? "?" : "")}>(ref reader, options);
-				#nullable enable
+				return ({typeName})System.Text.Json.JsonSerializer.Deserialize<{underlyingTypeName}>(ref reader, options){(underlyingType.IsValueType ? "" : "!")};
 			}}
 
-			public override void Write(System.Text.Json.Utf8JsonWriter writer, [AllowNull] {typeName} value, System.Text.Json.JsonSerializerOptions options)
+			public override void Write(System.Text.Json.Utf8JsonWriter writer, {typeName} value, System.Text.Json.JsonSerializerOptions options)
 			{{
-				if (value is null)
-					writer.WriteNullValue();
-				else
-					System.Text.Json.JsonSerializer.Serialize(writer, value.Value, options);
+				System.Text.Json.JsonSerializer.Serialize(writer, value.Value, options);
 			}}
 
 			{readAndWriteAsPropertyNameMethods}
@@ -390,7 +380,7 @@ namespace {containingNamespace}
 				return objectType == typeof({typeName});
 			}}
 
-			public override void WriteJson(Newtonsoft.Json.JsonWriter writer, [AllowNull] object value, Newtonsoft.Json.JsonSerializer serializer)
+			public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)
 			{{
 				if (value is null)
 					serializer.Serialize(writer, null);
@@ -398,14 +388,9 @@ namespace {containingNamespace}
 					serializer.Serialize(writer, (({typeName})value).Value);
 			}}
 
-			[return: MaybeNull]
-			public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, [AllowNull] object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+			public override object? ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)
 			{{
-				var value = serializer.Deserialize<{underlyingTypeName}{(underlyingType.IsValueType ? "?" : "")}>(reader);
-
-				#nullable disable
-				return ({typeName})value;
-				#nullable enable
+				return ({typeName}?)serializer.Deserialize<{underlyingTypeName}?>(reader);
 			}}
 		}}
 		{(existingComponents.HasFlags(WrapperValueObjectTypeComponents.NewtonsoftJsonConverter) ? "*/" : "")}

--- a/DomainModeling.Tests/Comparisons/DictionaryComparerTests.cs
+++ b/DomainModeling.Tests/Comparisons/DictionaryComparerTests.cs
@@ -1,13 +1,17 @@
-﻿using Architect.DomainModeling.Comparisons;
+using System.Diagnostics.CodeAnalysis;
+using Architect.DomainModeling.Comparisons;
 using Xunit;
 
 namespace Architect.DomainModeling.Tests.Comparisons;
 
 public class DictionaryComparerTests
 {
-	private static Dictionary<TKey, string> CreateDictionaryWithEqualityComparer<TKey>(IEnumerable<TKey> keys, IEqualityComparer<TKey> comparer)
+	[return: NotNullIfNotNull(nameof(keys))]
+	private static Dictionary<TKey, string>? CreateDictionaryWithEqualityComparer<TKey>(IEnumerable<TKey>? keys, IEqualityComparer<TKey> comparer)
+		where TKey : notnull
 	{
-		if (keys is null) return null;
+		if (keys is null)
+			return null;
 
 		var result = new Dictionary<TKey, string>(comparer);
 		foreach (var key in keys)
@@ -15,7 +19,7 @@ public class DictionaryComparerTests
 		return result;
 	}
 
-	private static void AssertGetHashCodesEqual<TKey, TValue>(bool expectedResult, IReadOnlyDictionary<TKey, TValue> left, IReadOnlyDictionary<TKey, TValue> right)
+	private static void AssertGetHashCodesEqual<TKey, TValue>(bool expectedResult, IReadOnlyDictionary<TKey, TValue>? left, IReadOnlyDictionary<TKey, TValue>? right)
 	{
 		var leftHashCode = DictionaryComparer.GetDictionaryHashCode(left);
 		var rightHashCode = DictionaryComparer.GetDictionaryHashCode(right);
@@ -29,13 +33,12 @@ public class DictionaryComparerTests
 		if (expectedResult) Assert.Equal(expectedResult, result);
 	}
 
-	private static void InterfaceAlternativesReturn<TKey, TValue>(bool expectedResult, Dictionary<TKey, TValue> left, Dictionary<TKey, TValue> right)
+	private static void InterfaceAlternativesReturn<TKey, TValue>(bool expectedResult, Dictionary<TKey, TValue>? left, Dictionary<TKey, TValue>? right)
+		where TKey : notnull
 		where TValue : IEquatable<TValue>
 	{
-#pragma warning disable IDE0004 // Cast is not redundant, but actually leads to a different overload
-		Assert.Equal(expectedResult, DictionaryComparer.DictionaryEquals((IDictionary<TKey, TValue>)left, (IDictionary<TKey, TValue>)right));
-		Assert.Equal(expectedResult, DictionaryComparer.DictionaryEquals((IReadOnlyDictionary<TKey, TValue>)left, (IReadOnlyDictionary<TKey, TValue>)right));
-#pragma warning restore IDE0004
+		Assert.Equal(expectedResult, DictionaryComparer.DictionaryEquals((IDictionary<TKey, TValue>?)left, (IDictionary<TKey, TValue>?)right));
+		Assert.Equal(expectedResult, DictionaryComparer.DictionaryEquals((IReadOnlyDictionary<TKey, TValue>?)left, (IReadOnlyDictionary<TKey, TValue>?)right));
 	}
 
 	[Theory]

--- a/DomainModeling.Tests/Comparisons/EnumerableComparerTests.cs
+++ b/DomainModeling.Tests/Comparisons/EnumerableComparerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Immutable;
 using Architect.DomainModeling.Comparisons;
 using Architect.DomainModeling.Tests.Comparisons.EnumerableComparerTestTypes;
@@ -127,7 +127,7 @@ namespace Architect.DomainModeling.Tests.Comparisons
 			return this.CreateCollectionCore(new[] { singleElement });
 		}
 
-		protected virtual IEnumerable<T> CreateCollectionWithEqualityComparer<T>(IEnumerable<T> elements, IComparer<T> comparer)
+		protected virtual IEnumerable<T>? CreateCollectionWithEqualityComparer<T>(IEnumerable<T> elements, IComparer<T> comparer)
 		{
 			return null;
 		}

--- a/DomainModeling.Tests/Comparisons/LookupComparerTests.cs
+++ b/DomainModeling.Tests/Comparisons/LookupComparerTests.cs
@@ -1,11 +1,13 @@
-﻿using Architect.DomainModeling.Comparisons;
+using System.Diagnostics.CodeAnalysis;
+using Architect.DomainModeling.Comparisons;
 using Xunit;
 
 namespace Architect.DomainModeling.Tests.Comparisons;
 
 public class LookupComparerTests
 {
-	private static ILookup<TKey, string> CreateLookupWithEqualityComparer<TKey>(IEnumerable<TKey> keys, IEqualityComparer<TKey> comparer)
+	[return: NotNullIfNotNull(nameof(keys))]
+	private static ILookup<TKey, string>? CreateLookupWithEqualityComparer<TKey>(IEnumerable<TKey>? keys, IEqualityComparer<TKey>? comparer)
 	{
 		if (keys is null) return null;
 
@@ -18,7 +20,7 @@ public class LookupComparerTests
 		return result;
 	}
 
-	private static void AssertGetHashCodesEqual<TKey, TValue>(bool expectedResult, ILookup<TKey, TValue> left, ILookup<TKey, TValue> right)
+	private static void AssertGetHashCodesEqual<TKey, TValue>(bool expectedResult, ILookup<TKey, TValue>? left, ILookup<TKey, TValue>? right)
 	{
 		var leftHashCode = LookupComparer.GetLookupHashCode(left);
 		var rightHashCode = LookupComparer.GetLookupHashCode(right);

--- a/DomainModeling.Tests/DomainModeling.Tests.csproj
+++ b/DomainModeling.Tests/DomainModeling.Tests.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>net7.0</TargetFramework>
 		<AssemblyName>Architect.DomainModeling.Tests</AssemblyName>
 		<RootNamespace>Architect.DomainModeling.Tests</RootNamespace>
+		<Nullable>Enable</Nullable>
 		<ImplicitUsings>Enable</ImplicitUsings>
 		<IsPackable>False</IsPackable>
 	</PropertyGroup>
@@ -14,9 +15,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/DomainModeling.Tests/Entities/Entity.SourceGeneratedIdentityTests.cs
+++ b/DomainModeling.Tests/Entities/Entity.SourceGeneratedIdentityTests.cs
@@ -242,9 +242,9 @@ public class SourceGeneratedIdentityTests
 		IntId? instance = value is null ? null : new IntId(value.Value);
 
 		if (expectedResult is null)
-			Assert.Throws<InvalidOperationException>(() => (int)instance);
+			Assert.Throws<InvalidOperationException>(() => (int)instance!);
 		else
-			Assert.Equal(expectedResult, (int)instance);
+			Assert.Equal(expectedResult, (int)instance!);
 	}
 
 	[Theory]
@@ -462,8 +462,8 @@ public class SourceGeneratedIdentityTests
 	public sealed class ComparableObject : IEquatable<ComparableObject>, IComparable<ComparableObject>
 	{
 		public override int GetHashCode() => 1;
-		public override bool Equals(object obj) => obj is ComparableObject other && this.Equals(other);
-		public bool Equals(ComparableObject other) => other is not null;
-		public int CompareTo(ComparableObject other) => other is null ? +1 : 0;
+		public override bool Equals(object? obj) => obj is ComparableObject other && this.Equals(other);
+		public bool Equals(ComparableObject? other) => other is not null;
+		public int CompareTo(ComparableObject? other) => other is null ? +1 : 0;
 	}
 }

--- a/DomainModeling.Tests/Entities/EntityTests.cs
+++ b/DomainModeling.Tests/Entities/EntityTests.cs
@@ -11,7 +11,7 @@ public class EntityTests
 	[InlineData(-1, false)]
 	public void DefaultId_WithClassId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var instance = new ClassIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var instance = new ClassIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(expectedResult, instance.HasDefaultId());
 	}
@@ -23,8 +23,8 @@ public class EntityTests
 	[InlineData(-1, true)]
 	public void GetHashCode_WithClassId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var one = new ClassIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		var two = new ClassIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var one = new ClassIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
+		var two = new ClassIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(expectedResult, one.GetHashCode().Equals(two.GetHashCode()));
 	}
@@ -36,8 +36,8 @@ public class EntityTests
 	[InlineData(-1, true)]
 	public void Equals_WithClassId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var one = new ClassIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		var two = new ClassIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var one = new ClassIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
+		var two = new ClassIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(one, one);
 		Assert.Equal(two, two);
@@ -171,7 +171,7 @@ public class EntityTests
 	[InlineData(-1, false)]
 	public void DefaultId_WithInterfaceId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var instance = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var instance = new InterfaceIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(expectedResult, instance.HasDefaultId());
 	}
@@ -183,8 +183,8 @@ public class EntityTests
 	[InlineData(-1, true)]
 	public void GetHashCode_WithInterfaceId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var one = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		var two = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var one = new InterfaceIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
+		var two = new InterfaceIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(expectedResult, one.GetHashCode().Equals(two.GetHashCode()));
 	}
@@ -196,8 +196,8 @@ public class EntityTests
 	[InlineData(-1, true)]
 	public void Equals_WithInterfaceId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var one = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		var two = new InterfaceIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var one = new InterfaceIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
+		var two = new InterfaceIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(one, one);
 		Assert.Equal(two, two);
@@ -211,7 +211,7 @@ public class EntityTests
 	[InlineData(-1, false)]
 	public void DefaultId_WithAbstractId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var instance = new AbstractIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var instance = new AbstractIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(expectedResult, instance.HasDefaultId());
 	}
@@ -223,8 +223,8 @@ public class EntityTests
 	[InlineData(-1, true)]
 	public void GetHashCode_WithAbstractId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var one = new AbstractIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		var two = new AbstractIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var one = new AbstractIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
+		var two = new AbstractIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(expectedResult, one.GetHashCode().Equals(two.GetHashCode()));
 	}
@@ -236,8 +236,8 @@ public class EntityTests
 	[InlineData(-1, true)]
 	public void Equals_WithAbstractId_ShouldEquateAsExpected(int? value, bool expectedResult)
 	{
-		var one = new AbstractIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
-		var two = new AbstractIdEntity(value is null ? null : new ConcreteId() { Value = value.Value, });
+		var one = new AbstractIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
+		var two = new AbstractIdEntity(value is null ? null! : new ConcreteId() { Value = value.Value, });
 
 		Assert.Equal(one, one);
 		Assert.Equal(two, two);
@@ -319,16 +319,16 @@ public class EntityTests
 	private abstract class AbstractId : IEquatable<AbstractId>, IId
 	{
 		public abstract override int GetHashCode();
-		public abstract override bool Equals(object obj);
-		public bool Equals(AbstractId other) => this.Equals((object)other);
-		public bool Equals(IId other) => this.Equals((object)other);
+		public abstract override bool Equals(object? obj);
+		public bool Equals(AbstractId? other) => this.Equals((object?)other);
+		public bool Equals(IId? other) => this.Equals((object?)other);
 	}
 
 	private sealed class ConcreteId : AbstractId, IEquatable<ConcreteId>
 	{
 		public override int GetHashCode() => this.Value.GetHashCode();
-		public override bool Equals(object obj) => obj is ConcreteId other && Equals(this.Value, other.Value);
-		public bool Equals(ConcreteId other) => this.Equals((object)other);
+		public override bool Equals(object? obj) => obj is ConcreteId other && Equals(this.Value, other.Value);
+		public bool Equals(ConcreteId? other) => this.Equals((object?)other);
 
 		public int Value { get; set; }
 	}

--- a/DomainModeling.Tests/IdentityTests.cs
+++ b/DomainModeling.Tests/IdentityTests.cs
@@ -292,9 +292,9 @@ namespace Architect.DomainModeling.Tests
 			var instance = value is null ? (IntId?)null : new IntId(value.Value);
 
 			if (expectedResult is null)
-				Assert.Throws<InvalidOperationException>(() => (int)instance);
+				Assert.Throws<InvalidOperationException>(() => (int)instance!);
 			else
-				Assert.Equal(expectedResult, (int)instance);
+				Assert.Equal(expectedResult, (int)instance!);
 		}
 
 		[Theory]
@@ -337,11 +337,11 @@ namespace Architect.DomainModeling.Tests
 		{
 			var intInstance = (IntId?)value;
 			Assert.Equal(value?.ToString() ?? "null", System.Text.Json.JsonSerializer.Serialize(intInstance));
-			if (value is not null) Assert.Equal(value?.ToString() ?? "null", System.Text.Json.JsonSerializer.Serialize(intInstance.Value));
+			if (intInstance is not null) Assert.Equal(value?.ToString() ?? "null", System.Text.Json.JsonSerializer.Serialize(intInstance.Value));
 
 			var stringInstance = (StringId?)value?.ToString();
 			Assert.Equal(value is null ? "null" : $@"""{value}""", System.Text.Json.JsonSerializer.Serialize(stringInstance));
-			if (value is not null) Assert.Equal(value is null ? "null" : $@"""{value}""", System.Text.Json.JsonSerializer.Serialize(stringInstance.Value));
+			if (stringInstance is not null) Assert.Equal(value is null ? "null" : $@"""{value}""", System.Text.Json.JsonSerializer.Serialize(stringInstance.Value));
 		}
 
 		[Theory]
@@ -352,11 +352,11 @@ namespace Architect.DomainModeling.Tests
 		{
 			var intInstance = (IntId?)value;
 			Assert.Equal(value?.ToString() ?? "null", Newtonsoft.Json.JsonConvert.SerializeObject(intInstance));
-			if (value is not null) Assert.Equal(value?.ToString() ?? "null", Newtonsoft.Json.JsonConvert.SerializeObject(intInstance.Value));
+			if (intInstance is not null) Assert.Equal(value?.ToString() ?? "null", Newtonsoft.Json.JsonConvert.SerializeObject(intInstance.Value));
 
 			var stringInstance = (StringId?)value?.ToString();
 			Assert.Equal(value is null ? "null" : $@"""{value}""", Newtonsoft.Json.JsonConvert.SerializeObject(stringInstance));
-			if (value is not null) Assert.Equal(value is null ? "null" : $@"""{value}""", Newtonsoft.Json.JsonConvert.SerializeObject(stringInstance.Value));
+			if (stringInstance is not null) Assert.Equal(value is null ? "null" : $@"""{value}""", Newtonsoft.Json.JsonConvert.SerializeObject(stringInstance.Value));
 		}
 
 		/// <summary>
@@ -435,7 +435,7 @@ namespace Architect.DomainModeling.Tests
 			Assert.Equal(value, System.Text.Json.JsonSerializer.Deserialize<DecimalId?>(json)?.Value);
 
 			if (json != "null")
-				Assert.Equal((decimal)value, System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json).Value);
+				Assert.Equal((decimal)value!, System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json).Value);
 		}
 
 		/// <summary>
@@ -454,7 +454,7 @@ namespace Architect.DomainModeling.Tests
 			Assert.Equal(value, Newtonsoft.Json.JsonConvert.DeserializeObject<DecimalId?>(json)?.Value);
 
 			if (json != "null")
-				Assert.Equal((decimal)value, System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json).Value);
+				Assert.Equal((decimal)value!, System.Text.Json.JsonSerializer.Deserialize<DecimalId>(json).Value);
 		}
 
 		[Theory]
@@ -464,11 +464,11 @@ namespace Architect.DomainModeling.Tests
 		{
 			json = $$"""{ "{{json}}": true }""";
 
-			Assert.Equal(KeyValuePair.Create((IntId)value, true), System.Text.Json.JsonSerializer.Deserialize<Dictionary<IntId, bool>>(json).Single());
+			Assert.Equal(KeyValuePair.Create((IntId)value, true), System.Text.Json.JsonSerializer.Deserialize<Dictionary<IntId, bool>>(json)?.Single());
 
-			Assert.Equal(KeyValuePair.Create((StringId)value.ToString(), true), System.Text.Json.JsonSerializer.Deserialize<Dictionary<StringId, bool>>(json).Single());
+			Assert.Equal(KeyValuePair.Create((StringId)value.ToString(), true), System.Text.Json.JsonSerializer.Deserialize<Dictionary<StringId, bool>>(json)?.Single());
 
-			Assert.Equal(KeyValuePair.Create((DecimalId)value, true), System.Text.Json.JsonSerializer.Deserialize<Dictionary<DecimalId, bool>>(json).Single());
+			Assert.Equal(KeyValuePair.Create((DecimalId)value, true), System.Text.Json.JsonSerializer.Deserialize<Dictionary<DecimalId, bool>>(json)?.Single());
 		}
 
 		[Theory]
@@ -526,10 +526,9 @@ namespace Architect.DomainModeling.Tests
 				this.Value = value;
 			}
 
-			[return: MaybeNull]
 			public override string ToString()
 			{
-				return this.Value.ToString();
+				return this.Value.ToString("0.#");
 			}
 
 			public override int GetHashCode()
@@ -537,7 +536,7 @@ namespace Architect.DomainModeling.Tests
 				return this.Value.GetHashCode();
 			}
 
-			public override bool Equals([AllowNull] object other)
+			public override bool Equals(object? other)
 			{
 				return other is FullySelfImplementedIdentity otherId && this.Equals(otherId);
 			}
@@ -575,7 +574,7 @@ namespace Architect.DomainModeling.Tests
 					return (FullySelfImplementedIdentity)System.Text.Json.JsonSerializer.Deserialize<int>(ref reader, options);
 				}
 
-				public override void Write(System.Text.Json.Utf8JsonWriter writer, [AllowNull] FullySelfImplementedIdentity value, System.Text.Json.JsonSerializerOptions options)
+				public override void Write(System.Text.Json.Utf8JsonWriter writer, FullySelfImplementedIdentity value, System.Text.Json.JsonSerializerOptions options)
 				{
 					System.Text.Json.JsonSerializer.Serialize(writer, value.Value, options);
 				}
@@ -600,7 +599,7 @@ namespace Architect.DomainModeling.Tests
 					return objectType == typeof(FullySelfImplementedIdentity) || objectType == typeof(FullySelfImplementedIdentity?);
 				}
 
-				public override void WriteJson(Newtonsoft.Json.JsonWriter writer, [AllowNull] object value, Newtonsoft.Json.JsonSerializer serializer)
+				public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer)
 				{
 					if (value is null)
 						serializer.Serialize(writer, null);
@@ -608,8 +607,7 @@ namespace Architect.DomainModeling.Tests
 						serializer.Serialize(writer, ((FullySelfImplementedIdentity)value).Value);
 				}
 
-				[return: MaybeNull]
-				public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, [AllowNull] object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+				public override object? ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer)
 				{
 					if (objectType == typeof(FullySelfImplementedIdentity)) // Non-nullable
 						return (FullySelfImplementedIdentity)serializer.Deserialize<int>(reader);

--- a/DomainModeling.Tests/ValueObjectTests.cs
+++ b/DomainModeling.Tests/ValueObjectTests.cs
@@ -756,7 +756,7 @@ namespace Architect.DomainModeling.Tests
 			var intInstance = value is null ? null : new IntValue(value.Value, value.Value);
 			Assert.Equal(value is null ? "null" : $@"{{""One"":{value},""Two"":{value},""CalculatedProperty"":""{value}-{value}""}}", System.Text.Json.JsonSerializer.Serialize(intInstance));
 
-			var stringInstance = value is null ? null : new StringValue(value.ToString(), value.ToString());
+			var stringInstance = value is null ? null : new StringValue(value.ToString()!, value.ToString()!);
 			Assert.Equal(value is null ? "null" : $@"{{""One"":""{value}"",""Two"":""{value}""}}", System.Text.Json.JsonSerializer.Serialize(stringInstance));
 		}
 
@@ -770,7 +770,7 @@ namespace Architect.DomainModeling.Tests
 			var intInstance = value is null ? null : new IntValue(value.Value, value.Value);
 			Assert.Equal(value is null ? "null" : $@"{{""One"":{value},""Two"":{value},""CalculatedProperty"":""{value}-{value}""}}", Newtonsoft.Json.JsonConvert.SerializeObject(intInstance));
 
-			var stringInstance = value is null ? null : new StringValue(value.ToString(), value.ToString());
+			var stringInstance = value is null ? null : new StringValue(value.ToString()!, value.ToString()!);
 			Assert.Equal(value is null ? "null" : $@"{{""One"":""{value}"",""Two"":""{value}""}}", Newtonsoft.Json.JsonConvert.SerializeObject(stringInstance));
 		}
 
@@ -823,18 +823,20 @@ namespace Architect.DomainModeling.Tests
 				Assert.Null(result);
 			else
 			{
+				Assert.NotNull(result);
 				Assert.Equal(value, result.One);
 				Assert.Equal(value, result.Two);
 			}
 
-			json = json == "null" ? json : json.Replace(value.ToString(), $@"""{value}""");
+			json = json == "null" ? json : json.Replace(value.ToString()!, $@"""{value}""");
 
 			var stringResult = System.Text.Json.JsonSerializer.Deserialize<StringValue>(json);
 
 			if (value is null)
-				Assert.Null(result);
+				Assert.Null(stringResult);
 			else
 			{
+				Assert.NotNull(stringResult);
 				Assert.Equal(value.ToString(), stringResult.One);
 				Assert.Equal(value.ToString(), stringResult.Two);
 			}
@@ -852,18 +854,20 @@ namespace Architect.DomainModeling.Tests
 				Assert.Null(result);
 			else
 			{
+				Assert.NotNull(result);
 				Assert.Equal(value, result.One);
 				Assert.Equal(value, result.Two);
 			}
 
-			json = json == "null" ? json : json.Replace(value.ToString(), $@"""{value}""");
+			json = json == "null" ? json : json.Replace(value.ToString()!, $@"""{value}""");
 
 			var stringResult = Newtonsoft.Json.JsonConvert.DeserializeObject<StringValue>(json);
 
 			if (value is null)
-				Assert.Null(result);
+				Assert.Null(stringResult);
 			else
 			{
+				Assert.NotNull(stringResult);
 				Assert.Equal(value.ToString(), stringResult.One);
 				Assert.Equal(value.ToString(), stringResult.Two);
 			}
@@ -888,6 +892,7 @@ namespace Architect.DomainModeling.Tests
 				Assert.Null(result);
 			else
 			{
+				Assert.NotNull(result);
 				Assert.Equal(value.Value, result.One);
 				Assert.Equal(value.Value, result.Two);
 			}
@@ -912,6 +917,7 @@ namespace Architect.DomainModeling.Tests
 				Assert.Null(result);
 			else
 			{
+				Assert.NotNull(result);
 				Assert.Equal(value.Value, result.One);
 				Assert.Equal(value.Value, result.Two);
 			}
@@ -1055,9 +1061,9 @@ namespace Architect.DomainModeling.Tests
 		[SourceGenerated]
 		public sealed partial class DefaultComparingStringValue : ValueObject, IComparable<DefaultComparingStringValue>
 		{
-			public string Value { get; }
+			public string? Value { get; }
 
-			public DefaultComparingStringValue(string value)
+			public DefaultComparingStringValue(string? value)
 			{
 				this.Value = value;
 			}
@@ -1083,12 +1089,12 @@ namespace Architect.DomainModeling.Tests
 		[SourceGenerated]
 		public sealed partial class CustomCollectionValueObject : ValueObject
 		{
-			public CustomCollection Values { get; set; }
+			public CustomCollection? Values { get; set; }
 
 			public class CustomCollection : IReadOnlyCollection<int>
 			{
 				public override int GetHashCode() => 1;
-				public override bool Equals(object other) => true;
+				public override bool Equals(object? other) => true;
 				public int Count => throw new NotSupportedException();
 				public IEnumerator<int> GetEnumerator() => throw new NotSupportedException();
 				IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
@@ -1121,9 +1127,8 @@ namespace Architect.DomainModeling.Tests
 		[Newtonsoft.Json.JsonObject(Newtonsoft.Json.MemberSerialization.Fields)]
 		internal sealed partial class FullySelfImplementedValueObject : ValueObject, IComparable<FullySelfImplementedValueObject>
 		{
-			protected sealed override StringComparison StringComparison => StringComparison.Ordinal;
+			protected sealed override StringComparison StringComparison => throw new NotSupportedException("This operation applies to string-based value objects only.");
 
-			[return: NotNull]
 			public sealed override string ToString()
 			{
 				return $"{{FullySelfImplementedValueObject}}";
@@ -1134,37 +1139,33 @@ namespace Architect.DomainModeling.Tests
 				return typeof(FullySelfImplementedValueObject).GetHashCode();
 			}
 
-			public sealed override bool Equals([AllowNull] object other)
+			public sealed override bool Equals(object? other)
 			{
 				return other is FullySelfImplementedValueObject otherValue && this.Equals(otherValue);
 			}
 
-			public bool Equals([AllowNull] FullySelfImplementedValueObject other)
+			public bool Equals(FullySelfImplementedValueObject? other)
 			{
 				if (other is null) return false;
 
-				return
-					true;
+				return true; ;
 			}
 
-			public int CompareTo([AllowNull] FullySelfImplementedValueObject other)
+			// This method is generated only if the ValueObject implements IComparable<T> against its own type and each data member implements IComparable<T> against its own type
+			public int CompareTo(FullySelfImplementedValueObject? other)
 			{
 				if (other is null) return +1;
 
 				return 0;
 			}
 
-#nullable disable // The compiler fails to interpret nullable attributes on overloaded operators at the time of writing
+			public static bool operator ==(FullySelfImplementedValueObject? left, FullySelfImplementedValueObject? right) => left is null ? right is null : left.Equals(right);
+			public static bool operator !=(FullySelfImplementedValueObject? left, FullySelfImplementedValueObject? right) => !(left == right);
 
-			public static bool operator ==([AllowNull] FullySelfImplementedValueObject left, [AllowNull] FullySelfImplementedValueObject right) => left is null ? right is null : left.Equals(right);
-			public static bool operator !=([AllowNull] FullySelfImplementedValueObject left, [AllowNull] FullySelfImplementedValueObject right) => !(left == right);
-
-			public static bool operator >([AllowNull] FullySelfImplementedValueObject left, [AllowNull] FullySelfImplementedValueObject right) => left is not null && left.CompareTo(right) > 0;
-			public static bool operator <([AllowNull] FullySelfImplementedValueObject left, [AllowNull] FullySelfImplementedValueObject right) => left is null ? right is not null : left.CompareTo(right) < 0;
-			public static bool operator >=([AllowNull] FullySelfImplementedValueObject left, [AllowNull] FullySelfImplementedValueObject right) => !(left < right);
-			public static bool operator <=([AllowNull] FullySelfImplementedValueObject left, [AllowNull] FullySelfImplementedValueObject right) => !(left > right);
-
-#nullable enable // The compiler fails to interpret nullable attributes on overloaded operators at the time of writing
+			public static bool operator >(FullySelfImplementedValueObject? left, FullySelfImplementedValueObject? right) => left is not null && left.CompareTo(right) > 0;
+			public static bool operator <(FullySelfImplementedValueObject? left, FullySelfImplementedValueObject? right) => left is null ? right is not null : left.CompareTo(right) < 0;
+			public static bool operator >=(FullySelfImplementedValueObject? left, FullySelfImplementedValueObject? right) => !(left < right);
+			public static bool operator <=(FullySelfImplementedValueObject? left, FullySelfImplementedValueObject? right) => !(left > right);
 		}
 	}
 }

--- a/DomainModeling/Comparisons/DictionaryComparer.cs
+++ b/DomainModeling/Comparisons/DictionaryComparer.cs
@@ -14,7 +14,7 @@ public static class DictionaryComparer
 	/// Returns a hash code over some of the content of the given <paramref name="instance"/>.
 	/// </para>
 	/// </summary>
-	public static int GetDictionaryHashCode<TKey, TValue>([AllowNull] IReadOnlyDictionary<TKey, TValue> instance)
+	public static int GetDictionaryHashCode<TKey, TValue>(IReadOnlyDictionary<TKey, TValue>? instance)
 	{
 		// Unfortunately, we can do no better than distinguish between null, empty, and non-empty
 		// Example:
@@ -36,7 +36,7 @@ public static class DictionaryComparer
 	/// Returns a hash code over some of the content of the given <paramref name="instance"/>.
 	/// </para>
 	/// </summary>
-	public static int GetDictionaryHashCode<TKey, TValue>([AllowNull] IDictionary<TKey, TValue> instance)
+	public static int GetDictionaryHashCode<TKey, TValue>(IDictionary<TKey, TValue>? instance)
 	{
 		// Unfortunately, we can do no better than distinguish between null, empty, and non-empty
 		// Example:
@@ -58,7 +58,7 @@ public static class DictionaryComparer
 	/// Returns a hash code over some of the content of the given <paramref name="instance"/>.
 	/// </para>
 	/// </summary>
-	public static int GetDictionaryHashCode<TKey, TValue>([AllowNull] Dictionary<TKey, TValue> instance)
+	public static int GetDictionaryHashCode<TKey, TValue>(Dictionary<TKey, TValue>? instance)
 		where TKey : notnull
 	{
 		return GetDictionaryHashCode((IReadOnlyDictionary<TKey, TValue>?)instance);
@@ -73,7 +73,7 @@ public static class DictionaryComparer
 	/// It is not recursive. To support nested collections, use custom collections that override their equality checks accordingly.
 	/// </para>
 	/// </summary>
-	public static bool DictionaryEquals<TKey, TValue>([AllowNull] IReadOnlyDictionary<TKey, TValue> left, [AllowNull] IReadOnlyDictionary<TKey, TValue> right)
+	public static bool DictionaryEquals<TKey, TValue>(IReadOnlyDictionary<TKey, TValue>? left, IReadOnlyDictionary<TKey, TValue>? right)
 	{
 		// Devirtualized path for practically all dictionaries
 #pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint. -- Was type-checked
@@ -84,7 +84,7 @@ public static class DictionaryComparer
 		return GetResult(left, right);
 
 		// Local function that performs the work
-		static bool GetResult([AllowNull] IReadOnlyDictionary<TKey, TValue> left, [AllowNull] IReadOnlyDictionary<TKey, TValue> right)
+		static bool GetResult(IReadOnlyDictionary<TKey, TValue>? left, IReadOnlyDictionary<TKey, TValue>? right)
 		{
 			if (ReferenceEquals(left, right)) return true;
 			if (left is null || right is null) return false; // Double nulls are already handled above
@@ -112,7 +112,7 @@ public static class DictionaryComparer
 	/// It is not recursive. To support nested collections, use custom collections that override their equality checks accordingly.
 	/// </para>
 	/// </summary>
-	public static bool DictionaryEquals<TKey, TValue>([AllowNull] IDictionary<TKey, TValue> left, [AllowNull] IDictionary<TKey, TValue> right)
+	public static bool DictionaryEquals<TKey, TValue>(IDictionary<TKey, TValue>? left, IDictionary<TKey, TValue>? right)
 	{
 		// Devirtualized path for practically all dictionaries
 #pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint. -- Was type-checked
@@ -123,7 +123,7 @@ public static class DictionaryComparer
 		return GetResult(left, right);
 
 		// Local function that performs the work
-		static bool GetResult([AllowNull] IDictionary<TKey, TValue> left, [AllowNull] IDictionary<TKey, TValue> right)
+		static bool GetResult(IDictionary<TKey, TValue>? left, IDictionary<TKey, TValue>? right)
 		{
 			if (ReferenceEquals(left, right)) return true;
 			if (left is null || right is null) return false; // Double nulls are already handled above
@@ -151,7 +151,7 @@ public static class DictionaryComparer
 	/// It is not recursive. To support nested collections, use custom collections that override their equality checks accordingly.
 	/// </para>
 	/// </summary>
-	public static bool DictionaryEquals<TKey, TValue>([AllowNull] Dictionary<TKey, TValue> left, [AllowNull] Dictionary<TKey, TValue> right)
+	public static bool DictionaryEquals<TKey, TValue>(Dictionary<TKey, TValue>? left, Dictionary<TKey, TValue>? right)
 		where TKey : notnull
 	{
 		if (ReferenceEquals(left, right)) return true;

--- a/DomainModeling/DomainModeling.csproj
+++ b/DomainModeling/DomainModeling.csproj
@@ -23,10 +23,12 @@ Release notes:
 2.0.0:
 - BREAKING: Generated DummyBuilders now use UTC datetimes for generated defaults and for interpreting datetime strings.
 - Semi-breaking: Generated types no longer add [Serializable] attribute, since there would be no way to remove it.
+- Generated types are now easier to read, using ?-based nullables instead of attributes.
 - Identity and WrapperValueObject&lt;TValue&gt; types now honor the underlying type's nullability in ToString().
 - Identity and WrapperValueObject&lt;TValue&gt; types' generated System.Text.Json serializers now implement ReadAsPropertyName() and WriteAsPropertyName(), enabling serialization of such types when they are used as dictionary keys (only in .NET 7 and up).
 - DummyBuilderGenerator: WrapperValueObject&lt;string&gt; and IIdentity&lt;string&gt; constructor params now get a string value equal to the param name instead of the type name (e.g. "FirstName" and "LastName" instead of "ProperName" and "ProperName").
 - Added some missing nullable annotations.
+- IIdentity&lt;T&gt; now has an explicit notnull constraint (whereas before this was only indirectly enforced by its IEquatable&lt;T&gt; interface).
 - Identity types now serialize additional large numeric types as string, to avoid JavaScript overflows: UInt128 and Int128.
 - Identity types generated for Entity&lt;TId, TIdPrimitive&gt; now have a summary.
 - Identity types wrapping a non-nullable string now explain the non-nullness for default struct instances, in summaries for ToString(), Value, and convert-to-string operators.
@@ -64,7 +66,7 @@ Release notes:
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DomainModeling/IIdentity.cs
+++ b/DomainModeling/IIdentity.cs
@@ -9,6 +9,6 @@ namespace Architect.DomainModeling;
 /// </para>
 /// </summary>
 public interface IIdentity<T> : IValueObject
-	where T : IEquatable<T>, IComparable<T>
+	where T : notnull, IEquatable<T>, IComparable<T>
 {
 }


### PR DESCRIPTION
- Generated types are now easier to read, using ?-based nullables instead of attributes.
- IIdentity&lt;T&gt; now has an explicit notnull constraint (whereas before this was only indirectly enforced by its IEquatable&lt;T&gt; interface).
- Solution now has nullable enabled everywhere.
- Updated dependency packages.