### PR TITLE
Avoided use of the constructor outside of conversion operators.

### DIFF
--- a/DomainModeling.Generator/IdentityGenerator.cs
+++ b/DomainModeling.Generator/IdentityGenerator.cs
@@ -302,9 +302,9 @@ public class IdentityGenerator : SourceGenerator
 		if (idType.IsOrImplementsInterface(interf => interf.Name == "ISpanParsable" && interf.ContainingNamespace.HasFullName("System") && interf.Arity == 1 && interf.TypeArguments[0].Equals(idType, SymbolEqualityComparer.Default), out _))
 			propertyNameParseStatement = $"return reader.GetParsedString<{idTypeName}>(System.Globalization.CultureInfo.InvariantCulture);";
 		else if (underlyingType.IsType<string>())
-			propertyNameParseStatement = $"return new {idTypeName}(reader.GetString()!);";
+			propertyNameParseStatement = $"return ({idTypeName})reader.GetString()!;";
 		else if (!underlyingType.IsGeneric() && underlyingType.IsOrImplementsInterface(interf => interf.Name == "ISpanParsable" && interf.ContainingNamespace.HasFullName("System") && interf.Arity == 1 && interf.TypeArguments[0].Equals(underlyingType, SymbolEqualityComparer.Default), out _))
-			propertyNameParseStatement = $"return new {idTypeName}(reader.GetParsedString<{underlyingType.ContainingNamespace}.{underlyingType.Name}>(System.Globalization.CultureInfo.InvariantCulture));";
+			propertyNameParseStatement = $"return ({idTypeName})reader.GetParsedString<{underlyingType.ContainingNamespace}.{underlyingType.Name}>(System.Globalization.CultureInfo.InvariantCulture);";
 
 		var propertyNameFormatStatement = "writer.WritePropertyName(value.ToString());";
 		if (idType.IsOrImplementsInterface(interf => interf.Name == "ISpanFormattable" && interf.ContainingNamespace.HasFullName("System") && interf.Arity == 0, out _))

--- a/DomainModeling.Tests/IdentityTests.cs
+++ b/DomainModeling.Tests/IdentityTests.cs
@@ -582,7 +582,7 @@ namespace Architect.DomainModeling.Tests
 #if NET7_0_OR_GREATER
 				public override FullySelfImplementedIdentity ReadAsPropertyName(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
 				{
-					return new FullySelfImplementedIdentity(reader.GetParsedString<int>(CultureInfo.InvariantCulture));
+					return (FullySelfImplementedIdentity)reader.GetParsedString<int>(CultureInfo.InvariantCulture);
 				}
 
 				public override void WriteAsPropertyName(System.Text.Json.Utf8JsonWriter writer, FullySelfImplementedIdentity value, System.Text.Json.JsonSerializerOptions options)


### PR DESCRIPTION
Avoided use of the constructor outside of conversion operators (used oly in newly added methods).