### PR TITLE
Feature/2.1.0

### DIFF
--- a/DomainModeling.Generator/IdentityGenerator.cs
+++ b/DomainModeling.Generator/IdentityGenerator.cs
@@ -133,7 +133,7 @@ public class IdentityGenerator : SourceGenerator
 			existingComponents |= IdTypeComponents.GetHashCodeOverride.If(!result.IsRecord && members.Any(member =>
 				member.Name == nameof(GetHashCode) && member is IMethodSymbol method && method.Parameters.Length == 0));
 
-			// Records irrevocably and correctly override this to check the type and delegate to IEquatable<T>.Equals(T)
+			// Records irrevocably and correctly override this, checking the type and delegating to IEquatable<T>.Equals(T)
 			existingComponents |= IdTypeComponents.EqualsOverride.If(members.Any(member =>
 				member.Name == nameof(Equals) && member is IMethodSymbol method && method.Parameters.Length == 1 &&
 				method.Parameters[0].Type.IsType<object>()));
@@ -147,13 +147,13 @@ public class IdentityGenerator : SourceGenerator
 				member.Name == nameof(IComparable.CompareTo) && member is IMethodSymbol method && method.Parameters.Length == 1 &&
 				method.Parameters[0].Type.Equals(type, SymbolEqualityComparer.Default)));
 
-			// Records irrevocably and correctly override this to delegate to IEquatable<T>.Equals(T)
+			// Records irrevocably and correctly override this, delegating to IEquatable<T>.Equals(T)
 			existingComponents |= IdTypeComponents.EqualsOperator.If(members.Any(member =>
 				member.Name == "op_Equality" && member is IMethodSymbol method && method.Parameters.Length == 2 &&
 				method.Parameters[0].Type.Equals(type, SymbolEqualityComparer.Default) &&
 				method.Parameters[1].Type.Equals(type, SymbolEqualityComparer.Default)));
 
-			// Records irrevocably and correctly override this to delegate to IEquatable<T>.Equals(T)
+			// Records irrevocably and correctly override this, delegating to IEquatable<T>.Equals(T)
 			existingComponents |= IdTypeComponents.NotEqualsOperator.If(members.Any(member =>
 				member.Name == "op_Inequality" && member is IMethodSymbol method && method.Parameters.Length == 2 &&
 				method.Parameters[0].Type.Equals(type, SymbolEqualityComparer.Default) &&

--- a/DomainModeling.Generator/SourceGeneratedAttributeAnalyzer.cs
+++ b/DomainModeling.Generator/SourceGeneratedAttributeAnalyzer.cs
@@ -55,7 +55,7 @@ public class SourceGeneratedAttributeAnalyzer : SourceGenerator
 		else if (type.IsOrInheritsClass(type => type.Arity == 2 && type.IsType(Constants.DummyBuilderTypeName, Constants.DomainModelingNamespace), out _))
 			expectedTypeName = tds is ClassDeclarationSyntax ? null : "class"; // Expect a class
 		else if (type.IsOrImplementsInterface(type => type.Arity == 1 && type.IsType(Constants.IdentityInterfaceTypeName, Constants.DomainModelingNamespace), out _))
-			expectedTypeName = tds is StructDeclarationSyntax ? null : "struct"; // Expect a struct
+			expectedTypeName = tds is StructDeclarationSyntax or RecordDeclarationSyntax { ClassOrStructKeyword.ValueText: "struct" } ? null : "struct"; // Expect a struct
 		else
 			expectedTypeName = "*"; // No suitable inheritance found for source generation
 

--- a/DomainModeling.Generator/TypeSyntaxExtensions.cs
+++ b/DomainModeling.Generator/TypeSyntaxExtensions.cs
@@ -7,7 +7,11 @@ namespace Architect.DomainModeling.Generator;
 /// </summary>
 internal static class TypeSyntaxExtensions
 {
-	public static bool HasArityAndName(this TypeSyntax typeSyntax, int arity, string unqualifiedName)
+	/// <summary>
+	/// Returns whether the given <see cref="TypeSyntax"/> has the given arity (type parameter count) and (unqualified) name.
+	/// </summary>
+	/// <param name="arity">Pass null to accept any arity.</param>
+	public static bool HasArityAndName(this TypeSyntax typeSyntax, int? arity, string unqualifiedName)
 	{
 		int actualArity;
 		string actualUnqualifiedName;
@@ -32,6 +36,20 @@ internal static class TypeSyntaxExtensions
 			return false;
 		}
 
-		return actualArity == arity && actualUnqualifiedName == unqualifiedName;
+		return (arity is null || actualArity == arity) && actualUnqualifiedName == unqualifiedName;
+	}
+
+	/// <summary>
+	/// Returns the given <see cref="TypeSyntax"/>'s name, or null if no name can be obtained.
+	/// </summary>
+	public static string? GetNameOrDefault(this TypeSyntax typeSyntax)
+	{
+		return typeSyntax switch
+		{
+			SimpleNameSyntax simpleName => simpleName.Identifier.ValueText,
+			QualifiedNameSyntax qualifiedName => qualifiedName.Right.Identifier.ValueText,
+			AliasQualifiedNameSyntax aliasQualifiedName => aliasQualifiedName.Name.Identifier.ValueText,
+			_ => null,
+		};
 	}
 }

--- a/DomainModeling.Generator/ValueObjectGenerator.cs
+++ b/DomainModeling.Generator/ValueObjectGenerator.cs
@@ -18,7 +18,7 @@ public class ValueObjectGenerator : SourceGenerator
 
 	private static bool FilterSyntaxNode(SyntaxNode node, CancellationToken cancellationToken = default)
 	{
-		// Partial subclass
+		// Partial subclass with any inherited/implemented types
 		if (node is not ClassDeclarationSyntax cds || !cds.Modifiers.Any(SyntaxKind.PartialKeyword) || cds.BaseList is null)
 			return false;
 
@@ -29,11 +29,9 @@ public class ValueObjectGenerator : SourceGenerator
 				return true;
 		}
 
-		/* Supporting records has the following disadvantages:
-		 * - Allows the use of automatic properties. This generates a constructor and init-properties, stimulating non-validated ValueObjects, an antipattern.
-		 * - Overrides equality without an easy way to specify (or even think of) how to compare strings.
-		 * - Overrides equality without special-casing collections.
-		 * - Omits IComparable<T> and comparison operators.
+		/* Supporting records has the following issues:
+		 * - Cannot inherit from a non-record class (and vice versa).
+		 * - Promotes the use of "positional" (automatic) properties. This generates a constructor and init-properties, stimulating non-validated ValueObjects, an antipattern.
 		 * - Provides multiple nearly-identical solutions, reducing standardization.
 		// Partial record with some interface/base
 		if (node is RecordDeclarationSyntax rds && rds.Modifiers.Any(SyntaxKind.PartialKeyword) && rds.BaseList is not null)

--- a/DomainModeling.Tests/IdentityTests.cs
+++ b/DomainModeling.Tests/IdentityTests.cs
@@ -104,6 +104,28 @@ namespace Architect.DomainModeling.Tests
 			Assert.Equal(new StringId(""), left);
 		}
 
+		[Fact]
+		public void ObjectEquals_WithRegularStruct_ShouldReturnExpectedResult()
+		{
+			var one = (object)new IntId(1);
+			var alsoOne = (object)new IntId(1);
+			var two = (object)new IntId(2);
+
+			Assert.Equal(one, alsoOne);
+			Assert.NotEqual(one, two);
+		}
+
+		[Fact]
+		public void ObjectEquals_WithRecordStruct_ShouldReturnExpectedResult()
+		{
+			var one = (object)new DecimalId(1);
+			var alsoOne = (object)new DecimalId(1);
+			var two = (object)new DecimalId(2);
+
+			Assert.Equal(one, alsoOne);
+			Assert.NotEqual(one, two);
+		}
+
 		[Theory]
 		[InlineData(0, 0)]
 		[InlineData(0, 1)]
@@ -495,14 +517,10 @@ namespace Architect.DomainModeling.Tests
 		}
 
 		[SourceGenerated]
-		internal partial struct DecimalId : IIdentity<decimal>
-		{
-		}
+		internal partial record struct DecimalId : IIdentity<decimal>;
 
 		[SourceGenerated]
-		internal partial struct StringId : IIdentity<string>
-		{
-		}
+		internal partial record struct StringId : IIdentity<string>;
 
 		[SourceGenerated]
 		internal partial struct IgnoreCaseStringId : IIdentity<string>

--- a/DomainModeling.Tests/ValueObjectTests.cs
+++ b/DomainModeling.Tests/ValueObjectTests.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using Architect.DomainModeling.Tests.ValueObjectTestTypes;

--- a/DomainModeling/DomainModeling.csproj
+++ b/DomainModeling/DomainModeling.csproj
@@ -13,13 +13,18 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<VersionPrefix>2.0.1</VersionPrefix>
+		<VersionPrefix>2.1.0</VersionPrefix>
 		<Description>
 A complete Domain-Driven Design (DDD) toolset for implementing domain models, including base types and source generators.
 
 https://github.com/TheArchitectDev/Architect.DomainModeling
 
 Release notes:
+
+2.1.0:
+- Added ValueObject.ContainsNonPrintableCharactersOrDoubleQuotes(), a common validation requirement for proper names.
+- Explicitly declared identity types now support "record struct", allowing their curly braces to be omitted.
+- Added the IEntity interface, implemented by the Entity class and its derivatives.
 
 2.0.1:
 - Fixed a bug where arrays in (Wrapper)ValueObjects would trip the generator.

--- a/DomainModeling/Entity.cs
+++ b/DomainModeling/Entity.cs
@@ -100,6 +100,6 @@ public abstract class Entity<TId> : Entity, IEquatable<Entity<TId>?>
 /// </para>
 /// </summary>
 [Serializable]
-public abstract class Entity : DomainObject
+public abstract class Entity : DomainObject, IEntity
 {
 }

--- a/DomainModeling/IEntity.cs
+++ b/DomainModeling/IEntity.cs
@@ -1,0 +1,10 @@
+namespace Architect.DomainModeling;
+
+/// <summary>
+/// <para>
+/// An entity is a data model that is defined by its identity and a thread of continuity. It may be mutated during its life cycle.
+/// </para>
+/// </summary>
+public interface IEntity : IDomainObject
+{
+}

--- a/DomainModeling/ValueObject.ValidationHelpers.cs
+++ b/DomainModeling/ValueObject.ValidationHelpers.cs
@@ -378,7 +378,7 @@ public abstract partial class ValueObject
 	/// It does <em>not</em> detect whitespace characters, even if they are zero-width.
 	/// </para>
 	/// <para>
-	/// It returns true, unless the given <paramref name="text"/> consists exclusively of printable characters other than doubles quotes (").
+	/// It returns true, unless the given <paramref name="text"/> consists exclusively of printable characters that are not double quotes (").
 	/// </para>
 	/// <para>
 	/// </para>

--- a/DomainModeling/ValueObject.ValidationHelpers.cs
+++ b/DomainModeling/ValueObject.ValidationHelpers.cs
@@ -374,6 +374,59 @@ public abstract partial class ValueObject
 
 	/// <summary>
 	/// <para>
+	/// This method detects double quotes (") and non-printable characters, such as control characters.
+	/// It does <em>not</em> detect whitespace characters, even if they are zero-width.
+	/// </para>
+	/// <para>
+	/// It returns true, unless the given <paramref name="text"/> consists exclusively of printable characters other than doubles quotes (").
+	/// </para>
+	/// <para>
+	/// </para>
+	/// <para>
+	/// A parameter controls whether this method flags newline and tab characters, allowing single-line vs. multiline input to be validated.
+	/// </para>
+	/// </summary>
+	/// <param name="flagNewLinesAndTabs">Pass true to flag \r, \n, and \t as non-printable characters. Pass false to overlook them.</param>
+	protected static bool ContainsNonPrintableCharactersOrDoubleQuotes(ReadOnlySpan<char> text, bool flagNewLinesAndTabs)
+	{
+		return flagNewLinesAndTabs
+			? EvaluateIncludingNewLinesAndTabs(text)
+			: EvaluateOverlookingNewLinesAndTabs(text);
+
+		// Local function that performs the work while including \r, \n, and \t characters
+		static bool EvaluateIncludingNewLinesAndTabs(ReadOnlySpan<char> text)
+		{
+			foreach (var chr in text)
+			{
+				var category = Char.GetUnicodeCategory(chr);
+
+				if (category == UnicodeCategory.Control | category == UnicodeCategory.PrivateUse | category == UnicodeCategory.OtherNotAssigned | chr == '"')
+					return true;
+			}
+
+			return false;
+		}
+
+		// Local function that performs the work while overlooking \r, \n, and \t characters
+		static bool EvaluateOverlookingNewLinesAndTabs(ReadOnlySpan<char> text)
+		{
+			foreach (var chr in text)
+			{
+				var category = Char.GetUnicodeCategory(chr);
+
+				if (category == UnicodeCategory.Control | category == UnicodeCategory.PrivateUse | category == UnicodeCategory.OtherNotAssigned | chr == '"')
+				{
+					if (chr == '\r' | chr == '\n' | chr == '\t') continue; // Exempt
+					return true;
+				}
+			}
+
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// <para>
 	/// This method detects whitespace characters and non-printable characters.
 	/// </para>
 	/// <para>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `Entity<TId, TIdPrimitive>` base class is what triggers source generation of
 
 For performance reasons, the `Entity<TId, TIdPrimitive>` base class is only recognized when inherited from _directly_. If it is _indirectly_ inherited from (i.e. via a custom base class), then the ID type must be [explicitly declared](#identity).
 
-The entity could then be modified as follows to create a new, unique ID on construction:
+Next, the entity could be modified as follows to create a new, unique ID on construction:
 
 ```cs
 public Payment(string currency, decimal amount)
@@ -159,7 +159,7 @@ public Payment(string currency, decimal amount)
 }
 ```
 
-For a more database-friendly alternative to GUIDs, see [Distributed IDs](https://github.com/TheArchitectDev/Architect.Identities#distributed-ids).
+For a more database-friendly alternative to UUIDs, see [Distributed IDs](https://github.com/TheArchitectDev/Architect.Identities#distributed-ids).
 
 ## Identity
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The `Entity<TId, TIdPrimitive>` base class is what triggers source generation of
 
 For performance reasons, the `Entity<TId, TIdPrimitive>` base class is only recognized when inherited from _directly_. If it is _indirectly_ inherited from (i.e. via a custom base class), then the ID type must be [explicitly declared](#identity).
 
-Next, the entity could be modified as follows to create a new, unique ID on construction:
+Next, the entity could be modified to create a new, unique ID on construction:
 
 ```cs
 public Payment(string currency, decimal amount)
@@ -163,11 +163,11 @@ For a more database-friendly alternative to UUIDs, see [Distributed IDs](https:/
 
 ## Identity
 
-Identity types are a special case of value objects. Unlike other value objects, they are perfectly suitable to be implemented as structs, for the following reasons:
+Identity types are a special case of value objects. Unlike other value objects, they are perfectly suitable to be implemented as structs:
 
-- The enforced default constructor is unproblematic, because there is hardly such a thing as an invalid ID value: although ID 0 or -1 might not _exist_, the same might be true for ID 999999, which would still be valid as a value.
-- The possibility of an ID variable containing `null` is often undesirable. Structs avoid this complication. (Where we _want_ nullability, a nullable struct (e.g. `PaymentId?`) can be used.)
-- If the underlying type is `string`, the generator ensures that its `Value` property returns the empty string instead of null. This way, even `string`-wrapping identities know only one "empty" value and avoid representing null.
+- The enforced default constructor is unproblematic, because there is hardly such a thing as an invalid ID value. Although ID 0 or -1 might not _exist_, the same might be true for ID 999999, which would still be valid as a value.
+- The possibility of an ID variable containing `null` is often undesirable. Structs avoid this complication. (Where we _want_ nullability, a nullable struct can be used, e.g. `PaymentId?`.
+- If the underlying type is `string`, the generator ensures that its `Value` property returns the empty string instead of `null`. This way, even `string`-wrapping identities know only one "empty" value and avoid representing `null`.
 
 Since an application is expected to work with many ID instances, using structs for them is a nice optimization that reduces heap allocations.
 


### PR DESCRIPTION
- Added ValueObject.ContainsNonPrintableCharactersOrDoubleQuotes(), a common validation requirement for proper names.
- Explicitly declared identity types now support "record struct", allowing their curly braces to be omitted.
- Added the IEntity interface, implemented by the Entity class and its derivatives.

Resolves #20.